### PR TITLE
Fix set-satis-output-url-prefix.js crashing when url has a subdirectory

### DIFF
--- a/bin/set-satis-output-url-prefix.js
+++ b/bin/set-satis-output-url-prefix.js
@@ -22,6 +22,8 @@ if (mirrorUrl.substr(-1) !== '/') {
   mirrorUrl += '/';
 }
 
+let parsedUrl = new URL(mirrorUrl);
+
 if (!fs.existsSync(satisOutputDir)) {
   console.log(`Unable to find satis output dir ${satisOutputDir}`);
   process.exit(2);
@@ -72,10 +74,12 @@ for (const includeFileName in (packages.includes || {})) {
   writeJson(includeFile, newIncludeData);
 }
 
-const packagePathTemplate = packages['metadata-url'];
+let packagePathTemplate = packages['metadata-url'];
+if (packagePathTemplate.startsWith(parsedUrl.pathname)) {
+    packagePathTemplate = '/' + packagePathTemplate.slice(parsedUrl.pathname.length);
+}
 for (const packageName of packages['available-packages']) {
   const packageFilePath = path.join(satisOutputDir, packagePathTemplate.replace('%package%', packageName));
-  
   const packageData = JSON.parse(fs.readFileSync(packageFilePath));
 
   packageData.packages[packageName] = (packageData.packages[packageName] || []).map(packageRelease => {


### PR DESCRIPTION
I'm trying to build it in a subdirectory, like `https://example.com/mirror`. The build script ends up crashing:
```
mirror-generator_1  | Writing packages.json
mirror-generator_1  | Pruning include directories
mirror-generator_1  | Writing web view
mirror-generator_1  | Setting url prefix in generated output to https://example.com/mirror...
mirror-generator_1  | node:internal/fs/utils:344
mirror-generator_1  |     throw err;
mirror-generator_1  |     ^
mirror-generator_1  |
mirror-generator_1  | Error: ENOENT: no such file or directory, open '/build/mirror/p2/amzn/amazon-pay-and-login-magento-2-module.json'
mirror-generator_1  |     at Object.openSync (node:fs:585:3)
mirror-generator_1  |     at Object.readFileSync (node:fs:453:35)
mirror-generator_1  |     at Object.<anonymous> (/generate-repo/bin/set-satis-output-url-prefix.js:79:37)
mirror-generator_1  |     at Module._compile (node:internal/modules/cjs/loader:1103:14)
mirror-generator_1  |     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
mirror-generator_1  |     at Module.load (node:internal/modules/cjs/loader:981:32)
mirror-generator_1  |     at Function.Module._load (node:internal/modules/cjs/loader:822:12)
mirror-generator_1  |     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
mirror-generator_1  |     at node:internal/main/run_main_module:17:47 {
mirror-generator_1  |   errno: -2,
mirror-generator_1  |   syscall: 'open',
mirror-generator_1  |   code: 'ENOENT',
mirror-generator_1  |   path: '/build/mirror/p2/amzn/amazon-pay-and-login-magento-2-module.json'
mirror-generator_1  | }
mageos_mirror-generator_1 exited with code 1
```

It's because the relative paths are being based off of the `metadata-url` in the generated `package.json`:
```
...
    "metadata-url": "/mirror/p2/%package%.json",
...
```

But the files are just in the `/build/` directory, so that won't resolve properly.