### PR TITLE
add adobe stock metapackage overrides for magento 2.4.3

### DIFF
--- a/src/build-config/mirror-build-config.js
+++ b/src/build-config/mirror-build-config.js
@@ -48,6 +48,26 @@ const mirrorBuildConfig = {
         "magento/module-adobe-stock-image": "1.3.0",
         "magento/module-adobe-stock-image-admin-ui": "1.3.0",
         "magento/module-adobe-stock-image-api": "1.3.0",
+      },
+      "2.1.2": {
+        "magento/module-adobe-stock-admin-ui": "1.3.0",
+        "magento/module-adobe-stock-asset": "1.3.0",
+        "magento/module-adobe-stock-asset-api": "2.0.0",
+        "magento/module-adobe-stock-client": "1.3.1",
+        "magento/module-adobe-stock-client-api": "2.1.0",
+        "magento/module-adobe-stock-image": "1.3.1",
+        "magento/module-adobe-stock-image-admin-ui": "1.3.1",
+        "magento/module-adobe-stock-image-api": "1.3.0",
+      },
+      "2.1.2-p1": {
+        "magento/module-adobe-stock-admin-ui": "1.3.0-p1",
+        "magento/module-adobe-stock-asset": "1.3.0-p1",
+        "magento/module-adobe-stock-asset-api": "2.0.0-p1",
+        "magento/module-adobe-stock-client": "1.3.1-p1",
+        "magento/module-adobe-stock-client-api": "2.1.0-p1",
+        "magento/module-adobe-stock-image": "1.3.1-p1",
+        "magento/module-adobe-stock-image-admin-ui": "1.3.1-p1",
+        "magento/module-adobe-stock-image-api": "1.3.0-p1",
       }
     }
   },


### PR DESCRIPTION
MageOS:
```
$ composer show magento/adobe-stock-integration
<snip>
requires
magento/adobe-ims *
magento/module-adobe-stock-admin-ui *
magento/module-adobe-stock-asset *
magento/module-adobe-stock-asset-api *
magento/module-adobe-stock-client *
magento/module-adobe-stock-client-api *
magento/module-adobe-stock-image *
magento/module-adobe-stock-image-admin-ui *
magento/module-adobe-stock-image-api *
```

Magento:
```
$ composer show magento/adobe-stock-integration
<snip>
requires
magento/adobe-ims *
magento/module-adobe-stock-admin-ui 1.3.0-p1
magento/module-adobe-stock-asset 1.3.0-p1
magento/module-adobe-stock-asset-api 2.0.0-p1
magento/module-adobe-stock-client 1.3.1-p1
magento/module-adobe-stock-client-api 2.1.0-p1
magento/module-adobe-stock-image 1.3.1-p1
magento/module-adobe-stock-image-admin-ui 1.3.1-p1
magento/module-adobe-stock-image-api 1.3.0-p1

```