### PR TITLE
magento 2.4.3 should not use p1 version of adobe-stock-integration

### DIFF
--- a/resource/history/magento/product-community-edition/2.4.3.json
+++ b/resource/history/magento/product-community-edition/2.4.3.json
@@ -7,7 +7,7 @@
     "dotmailer/dotmailer-magento2-extension-package": "4.12.0",
     "klarna/m2-payments": "8.3.2",
     "magento/adobe-ims": "2.1.2",
-    "magento/adobe-stock-integration": "2.1.2-p1",
+    "magento/adobe-stock-integration": "2.1.2",
     "magento/google-shopping-ads": "4.0.1",
     "paypal/module-braintree": "4.2.4",
     "temando/module-shipping": "2.0.0",


### PR DESCRIPTION
**DO NOT MERGE UNTIL https://github.com/magento/adobe-stock-integration/issues/1871 RESOLVED**

```
$ composer show magento/product-community-edition
name     : magento/product-community-edition
descrip. : eCommerce Platform for Growth (Community Edition)
keywords : 
versions : * 2.4.3
```

```
$ composer show magento/adobe-stock-integration
name     : magento/adobe-stock-integration
descrip. : Adobe Stock integration
keywords : 
versions : * 2.1.2
```