### PR TITLE
fix page-builder metapackage versions

### DIFF
--- a/src/build-config/mirror-build-config.js
+++ b/src/build-config/mirror-build-config.js
@@ -30,6 +30,24 @@ const mirrorBuildConfig = {
   'page-builder': {
     repoUrl: 'https://github.com/mage-os/mirror-magento2-page-builder.git',
     fromTag: '1.7.0',
+    fixVersions: {
+      "1.7.0": {
+        "magento/module-aws-s3-page-builder": "1.0.1",
+        "magento/module-catalog-page-builder-analytics": "1.6.1",
+        "magento/module-cms-page-builder-analytics": "1.6.1",
+        "magento/module-page-builder": "2.2.1",
+        "magento/module-page-builder-admin-analytics": "1.1.1",
+        "magento/module-page-builder-analytics": "1.6.1",
+      },
+      "1.7.0-p1": {
+        "magento/module-aws-s3-page-builder": "1.0.1-p1",
+        "magento/module-catalog-page-builder-analytics": "1.6.1-p1",
+        "magento/module-cms-page-builder-analytics": "1.6.1-p1",
+        "magento/module-page-builder": "2.2.1-p1",
+        "magento/module-page-builder-admin-analytics": "1.1.1-p1",
+        "magento/module-page-builder-analytics": "1.6.1-p1",
+      }
+    }
   },
   'adobe-ims': {
     repoUrl: 'https://github.com/mage-os/mirror-adobe-ims.git',


### PR DESCRIPTION
Magento:

```
$ composer show magento/page-builder
<snip>
versions : * 1.7.0
<snip>
requires
magento/module-aws-s3-page-builder 1.0.1
magento/module-catalog-page-builder-analytics 1.6.1
magento/module-cms-page-builder-analytics 1.6.1
magento/module-page-builder 2.2.1
magento/module-page-builder-admin-analytics 1.1.1
magento/module-page-builder-analytics 1.6.1
```

MageOS:

```
$ composer show magento/page-builder
<snip>
versions : * 1.7.0
<snip>
requires
magento/module-aws-s3-page-builder *
magento/module-catalog-page-builder-analytics *
magento/module-cms-page-builder-analytics *
magento/module-page-builder *
magento/module-page-builder-admin-analytics *
magento/module-page-builder-analytics *

```