### PR TITLE
Revert "magento 2.4.3 should not use p1 version of adobe-stock-integration"

### DIFF
--- a/resource/history/magento/product-community-edition/2.4.3.json
+++ b/resource/history/magento/product-community-edition/2.4.3.json
@@ -7,7 +7,7 @@
     "dotmailer/dotmailer-magento2-extension-package": "4.12.0",
     "klarna/m2-payments": "8.3.2",
     "magento/adobe-ims": "2.1.2",
-    "magento/adobe-stock-integration": "2.1.2",
+    "magento/adobe-stock-integration": "2.1.2-p1",
     "magento/google-shopping-ads": "4.0.1",
     "paypal/module-braintree": "4.2.4",
     "temando/module-shipping": "2.0.0",


### PR DESCRIPTION
This reverts commit d8cc66f156d3a76db193be2bbd69ba8fd52a682d.

My bad, this https://github.com/mage-os/generate-mirror-repo-js/pull/10 should not have been merged yet.