### PR TITLE
lower magento2 fromTag

### DIFF
--- a/src/build-config/mirror-build-config.js
+++ b/src/build-config/mirror-build-config.js
@@ -4,7 +4,7 @@ const packagesConfig = require('./packages-config');
 const mirrorBuildConfig = {
   'magento2': {
     repoUrl: 'https://github.com/mage-os/mirror-magento2.git',
-    fromTag: '2.3.7-p3',
+    fromTag: '2.3.7',
     fixVersions: {
       // Upstream correctly sets the module version to 100.3.7-p3 in the git tag, but in the actual upstream 2.3.7-p3
       // release they used 100.3.7 as the dependency.


### PR DESCRIPTION
Since we're building 100.3.7, which exists in tag 2.3.7.

2.3.7-p3 > 2.3.7 so it was never picked up.