### PR TITLE
fix: composer api compat error during build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
       - run: curl -L https://github.com/mage-os/php-dependency-list/raw/main/php-classes.phar -o /usr/local/bin/php-classes.phar && chmod +x /usr/local/bin/php-classes.phar
         name: "Install PHP source code dependency analyzer and make executable (used by nightly build script for base package)"
 
-      - run: composer create-project composer/satis:dev-main
+      - run: composer create-project composer/satis:dev-main#fafc1c2eca6394235f12f8a3ee4da7fc7c9fc874
       - run: npm ci
       - run: node ${{ env.entrypoint }} --outputDir=build/packages --gitRepoDir=generate-repo/repositories --repoUrl="${{ env.repo }}"
         name: "Generate the packages for the composer repo"


### PR DESCRIPTION
This change locks satis to the commit [fafc1c2eca6394235f12f8a3ee4da7fc7c9fc874](https://github.com/composer/satis/commit/fafc1c2eca6394235f12f8a3ee4da7fc7c9fc874).

#### Background:

Builds init the required php infra with composer create-project composer/satis:dev-main This pulls in composer 2.3.0 as a dependency at the time of writing However, the result is a [broken upstream nightly and mageos nightly build](https://github.com/mage-os/generate-mirror-repo-js/actions/runs/3507577283/jobs/5875381799) when composer install is run while determining the base package dependencies. The error is:

    - laminas/laminas-dependency-plugin 2.5.0 requires composer-plugin-api >=1.1.0 <2.3.0
               -> found composer-plugin-api[2.3.0] but it does not match the constraint.

The commit [bf82c45f818b5061e17be0eeaf5664c02d370274](https://github.com/composer/satis/commit/bf82c45f818b5061e17be0eeaf5664c02d370274) of composer/satis has the message "Make satis compatible with composer 2.3, 2.4 and add plugin mode"
The parent commit is [fafc1c2eca6394235f12f8a3ee4da7fc7c9fc874](https://github.com/composer/satis/commit/fafc1c2eca6394235f12f8a3ee4da7fc7c9fc874)