### PR TITLE
Fix composer version for deps determination

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
       - run: curl -L https://github.com/mage-os/php-dependency-list/raw/main/php-classes.phar -o /usr/local/bin/php-classes.phar && chmod +x /usr/local/bin/php-classes.phar
         name: "Install PHP source code dependency analyzer and make executable (used by nightly build script for base package)"
 
-      - run: composer create-project composer/satis:dev-main#fafc1c2eca6394235f12f8a3ee4da7fc7c9fc874
+      - run: composer create-project composer/satis:dev-main
       - run: npm ci
       - run: node ${{ env.entrypoint }} --outputDir=build/packages --gitRepoDir=generate-repo/repositories --repoUrl="${{ env.repo }}"
         name: "Generate the packages for the composer repo"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 8.1
-          tools: composer:v2
+          tools: composer:2.2
       - uses: actions/setup-node@v3
         with:
           node-version: 16


### PR DESCRIPTION
This is to avoid a build error during composer create-project:

 - laminas/laminas-dependency-plugin 2.5.0 requires composer-plugin-api >=1.1.0 <2.3.0
    -> found composer-plugin-api[2.3.0] but it does not match the constraint.