### PR TITLE
[feat] Add composer config transformations

### DIFF
--- a/src/build-config/upstream-nightly-build-config.js
+++ b/src/build-config/upstream-nightly-build-config.js
@@ -5,6 +5,18 @@ const branchBuildConfig = {
   'magento2': {
     repoUrl: 'https://github.com/mage-os/mirror-magento2.git',
     ref: '2.4-develop',
+    transform: {
+      // For magento/elasticsearch-8, remove the elasticsearch/elasticsearch dependency.
+      // See https://github.com/magento/magento2/issues/36687
+      'magento/module-elasticsearch-8': [
+        composerJson => {
+          if (composerJson?.require['elasticsearch/elasticsearch']) {
+            delete composerJson.require['elasticsearch/elasticsearch'];
+          }
+          return composerJson;
+        }
+      ]
+    }
   },
   'security-package': {
     repoUrl: 'https://github.com/mage-os/mirror-security-package.git',

--- a/src/package-modules.js
+++ b/src/package-modules.js
@@ -229,7 +229,7 @@ async function createPackageForRef(url, moduleDir, ref, options) {
     throw {message: `Unable to find composer.json for ${ref}, skipping ${magentoName}`}
   }
   
-  const composerConfig = JSON.parse(composerJson);
+  let composerConfig = JSON.parse(composerJson);
   
   let name, version;
   
@@ -284,7 +284,7 @@ async function createPackageForRef(url, moduleDir, ref, options) {
   }
   setDependencyVersions(composerConfig, dependencyVersions);
 
-  const finalComposerConfig = (transform && transform[name] || []).reduce((config, transformFn) => transformFn(config), composerConfig);
+  composerConfig = (transform && transform[name] || []).reduce((config, transformFn) => transformFn(config), composerConfig);
 
   const filesInZip = files.map(file => {
     file.mtime = mtime;
@@ -292,7 +292,7 @@ async function createPackageForRef(url, moduleDir, ref, options) {
     return file;
   });
   
-  filesInZip.push({filepath: 'composer.json', contentBuffer: Buffer.from(JSON.stringify(finalComposerConfig, null, 2), 'utf8'), mtime, isExecutable: false});
+  filesInZip.push({filepath: 'composer.json', contentBuffer: Buffer.from(JSON.stringify(composerConfig, null, 2), 'utf8'), mtime, isExecutable: false});
   for (const d of (emptyDirsToAdd || [])) {
     filesInZip.push({filepath: d, contentBuffer: false, mtime, isExecutable: false});
   }
@@ -538,7 +538,7 @@ async function determineMetaPackageFromRepoDir(url, dir, ref, release) {
  */
 async function createMetaPackageFromRepoDir(url, dir, ref, options) {
   const {release, dependencyVersions, transform} = Object.assign({release: undefined, dependencyVersions: {}}, (options || {}));
-  const composerConfig = JSON.parse(await readComposerJson(url, dir, ref));
+  let composerConfig = JSON.parse(await readComposerJson(url, dir, ref));
   let {version, name} = composerConfig;
   if (!name) {
     throw {message: `Unable find package name and in composer.json for metapackage ${ref} in ${dir}`}
@@ -550,12 +550,12 @@ async function createMetaPackageFromRepoDir(url, dir, ref, options) {
   composerConfig.version = version;
   setDependencyVersions(composerConfig, dependencyVersions);
 
-  const finalComposerConfig = (transform && transform[name] || []).reduce((config, transformFn) => transformFn(config), composerConfig);
+  composerConfig = (transform && transform[name] || []).reduce((config, transformFn) => transformFn(config), composerConfig);
 
   const files = [{
     filepath: 'composer.json',
     mtime: new Date(stableMtime),
-    contentBuffer: Buffer.from(JSON.stringify(finalComposerConfig, null, 2), 'utf8'),
+    contentBuffer: Buffer.from(JSON.stringify(composerConfig, null, 2), 'utf8'),
     isExecutable: false,
   }];
 

--- a/src/release-branch-build-tools.js
+++ b/src/release-branch-build-tools.js
@@ -125,14 +125,14 @@ async function processBuildInstruction(instruction, dependencyVersions, fallback
   const packages = {}
   let built = {};
 
-  const {repoUrl, ref, release} = instruction;
+  const {repoUrl, ref, release, transform} = instruction;
 
   await repo.pull(repoUrl, ref);
 
   for (const packageDir of (instruction.packageDirs || [])) {
     const {label, dir, excludes} = Object.assign({excludes: []}, packageDir);
     console.log(`Packaging ${label}`);
-    built = await createPackagesForRef(repoUrl, dir, ref, {excludes, release, fallbackVersion, dependencyVersions});
+    built = await createPackagesForRef(repoUrl, dir, ref, {excludes, release, fallbackVersion, dependencyVersions, transform});
     Object.assign(packages, built);
   }
 
@@ -140,27 +140,27 @@ async function processBuildInstruction(instruction, dependencyVersions, fallback
     const defaults = {excludes: [], composerJsonPath: '', emptyDirsToAdd: []};
     const {label, dir, excludes, composerJsonPath, emptyDirsToAdd} = Object.assign(defaults, individualPackage);
     console.log(`Packaging ${label}`);
-    built = await createPackageForRef(repoUrl, dir, ref, {excludes, composerJsonPath, emptyDirsToAdd, release, fallbackVersion, dependencyVersions});
+    built = await createPackageForRef(repoUrl, dir, ref, {excludes, composerJsonPath, emptyDirsToAdd, release, fallbackVersion, dependencyVersions, transform});
     Object.assign(packages, built);
   }
 
   for (const packageMeta of (instruction.packageMetaFromDirs || [])) {
     const {label, dir} = packageMeta;
     console.log(`Packaging ${label}`);
-    built = await createMetaPackageFromRepoDir(repoUrl, dir, ref, {release, dependencyVersions});
+    built = await createMetaPackageFromRepoDir(repoUrl, dir, ref, {release, dependencyVersions, transform});
     Object.assign(packages, built);
   }
 
   if (instruction.magentoCommunityEditionMetapackage) {
     console.log('Packaging Magento Community Edition Product Metapackage');
-    built = await createMagentoCommunityEditionMetapackage(repoUrl, ref, {release, dependencyVersions});
+    built = await createMagentoCommunityEditionMetapackage(repoUrl, ref, {release, dependencyVersions, transform});
     Object.assign(packages, built);
   }
 
   if (instruction.magentoCommunityEditionProject) {
     console.log('Packaging Magento Community Edition Project');
     const minimumStability = 'alpha';
-    built = await createMagentoCommunityEditionProject(repoUrl, ref, {release, dependencyVersions, minimumStability});
+    built = await createMagentoCommunityEditionProject(repoUrl, ref, {release, dependencyVersions, minimumStability, transform});
     Object.assign(packages, built);
   }
 


### PR DESCRIPTION
Allow arbitrary transformation functions for the composer.json contents of specific nightly packages.  
This is required for to emulate what Adobe does in 2.4.6-beta1.  
See https://github.com/magento/magento2/issues/36687
