### PR TITLE
chore: fix mirror builds

### DIFF
--- a/src/build-config/mirror-build-config.js
+++ b/src/build-config/mirror-build-config.js
@@ -118,6 +118,9 @@ const mirrorBuildConfig = {
   'composer-root-update-plugin': {
     repoUrl: 'https://github.com/mage-os/mirror-composer-root-update-plugin.git',
     fromTag: '1.0.0',
+    // Skip tag 2.0.3 until the expected release date of 2.4.6 because it probably was tagged by accident in upstream
+    // See issue https://github.com/magento/composer-root-update-plugin/issues/37
+    skipTags: {'2.0.3': () => (new Date('2023-03-14')).getTime() < Date.now()},
   },
   'composer-dependency-version-audit-plugin': {
     repoUrl: 'https://github.com/mage-os/mirror-composer-dependency-version-audit-plugin.git',


### PR DESCRIPTION
Exclude composer-root-update-plugin 2.0.3 until expected release of Magento Open Source 2.4.6 since by that time we expect the package to be available in repo.magento.com, too.
Currently it is tagged in the public github repo, but not available on repo.magento.com.