### PR TITLE
Update ssh-deploy action, fixes #36

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
       - run: cd satis && node ../bin/set-satis-output-url-prefix.js --satisOutputDir=../build --repoUrl="${{ env.repo }}" && cd -
         name: "Fix path to packages in the packages.json satis created"
 
-      - uses: easingthemes/ssh-deploy@v4.0.5
+      - uses: easingthemes/ssh-deploy@v4
         name: "Rsync over SSH"
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
       - run: cd satis && node ../bin/set-satis-output-url-prefix.js --satisOutputDir=../build --repoUrl="${{ env.repo }}" && cd -
         name: "Fix path to packages in the packages.json satis created"
 
-      - uses: easingthemes/ssh-deploy@v2.2.11
+      - uses: easingthemes/ssh-deploy@v4.0.5
         name: "Rsync over SSH"
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}


### PR DESCRIPTION
The warning shown in #36 comes from an outdated version of https://github.com/easingthemes/ssh-deploy. I shortly read through the release notes and did not find anything serious, I think it could / should just work. Not sure if we can test this before, but we could also merge, check and revert if it does not work.