### PR TITLE
chore: add tag config for 2.4.6 adobe-ims packages

### DIFF
--- a/src/build-config/mirror-build-config.js
+++ b/src/build-config/mirror-build-config.js
@@ -67,6 +67,24 @@ const mirrorBuildConfig = {
   'adobe-ims': {
     repoUrl: 'https://github.com/mage-os/mirror-adobe-ims.git',
     fromTag: '2.1.0',
+    extraRefToRelease: [
+      // This is a workaround for a wrong upstream release tag, see https://github.com/magento/adobe-ims/issues/16
+      // This commit ref is the head for the develop branch (at the time of writing)  
+      // An alternative might be 75e4cc4673f117bf70ddbfe6bb4902575a3bb294 (the head for the future-develop branch at the time of writing))  
+      {
+        ref: 'c04d9360b4e03fc61f9fef447814a40091792b51',
+        release: '2.2.0',
+        details: 'Remove extraRefToRelease from mirror build config if https://github.com/magento/adobe-ims/issues/16 is resolved'
+      }
+    ],
+    fixVersions: {
+      '2.2.0': {
+        'magento/module-admin-adobe-ims': '100.5.0',
+        'magento/module-admin-adobe-ims-two-factor-auth': '1.0.0',
+        'magento/module-adobe-ims': '2.2.0',
+        'magento/module-adobe-ims-api': '2.2.0'
+      }
+    }
   },
   'adobe-stock-integration': {
     repoUrl: 'https://github.com/mage-os/mirror-adobe-stock-integration.git',

--- a/src/build-config/packages-config.js
+++ b/src/build-config/packages-config.js
@@ -145,7 +145,7 @@ module.exports = {
       {
         label: 'Adobe IMS Packages',
         dir: '',
-        excludes: ['_metapackage/', '.github/'],
+        excludes: ['_metapackage/', '.github/', 'i18n', 'dev'],
       }
     ],
     packageIndividual: [],


### PR DESCRIPTION
Guessing which commit represents 2.4.6 adobe-ims packages.