### PR TITLE
chore: remove .gitignore from extra.map since it is not in the repo

### DIFF
--- a/resource/history/magento/magento2-base/2.4.3-p3.json
+++ b/resource/history/magento/magento2-base/2.4.3-p3.json
@@ -76,10 +76,6 @@
                 ".editorconfig"
             ],
             [
-                ".gitignore",
-                ".gitignore"
-            ],
-            [
                 ".htaccess",
                 ".htaccess"
             ],

--- a/resource/history/magento/magento2-base/2.4.5-p2.json
+++ b/resource/history/magento/magento2-base/2.4.5-p2.json
@@ -69,10 +69,6 @@
                 ".editorconfig"
             ],
             [
-                ".gitignore",
-                ".gitignore"
-            ],
-            [
                 ".htaccess",
                 ".htaccess"
             ],

--- a/resource/history/magento/magento2-base/2.4.6.json
+++ b/resource/history/magento/magento2-base/2.4.6.json
@@ -68,10 +68,6 @@
                 ".editorconfig"
             ],
             [
-                ".gitignore",
-                ".gitignore"
-            ],
-            [
                 ".htaccess",
                 ".htaccess"
             ],


### PR DESCRIPTION
This will likely fix the magento-composer-installer plugin error for 2.4.4-p3, 2.4.5-p2 and 2.4.6.