### PR TITLE
fix: patch dependency version mismatch for release 2.3.7-p4

### DIFF
--- a/src/build-config/mirror-build-config.js
+++ b/src/build-config/mirror-build-config.js
@@ -91,6 +91,11 @@ const mirrorBuildConfig = {
     repoUrl: 'https://github.com/mage-os/mirror-adobe-stock-integration.git',
     fromTag: '1.0.0',
     fixVersions: {
+      '1.0.3-p3': {
+        // Upstream release wrongly pins module-adobe-stock-image-api 1.0.2, even though in that release
+        // module-adobe-stock-image-admin-ui requires 1.0.2-p1
+        "magento/module-adobe-stock-image-api": "1.0.2-p1",
+      },
       '1.0.3-p2': {
         // Upstream release ships with these deps, but in the tagged release * dependencies are used in the metapackage
         'magento/module-adobe-ims':                  '1.0.2-p1',


### PR DESCRIPTION
See https://github.com/mage-os/generate-mirror-repo-js/actions/runs/5113378862/jobs/9193781289