### PR TITLE
chore: fix the pinned versions for 1.0.3-p2 to fix the dependencies in 1.0.3-p3

### DIFF
--- a/src/build-config/mirror-build-config.js
+++ b/src/build-config/mirror-build-config.js
@@ -93,14 +93,14 @@ const mirrorBuildConfig = {
     fixVersions: {
       '1.0.3-p2': {
         // Upstream release ships with these deps, but in the tagged release * dependencies are used in the metapackage
-        'magento/module-adobe-ims':                  '1.0.2-p1',
-        'magento/module-adobe-ims-api':              '1.0.2-p1',
-        'magento/module-adobe-stock-admin-ui':       '1.0.2-p1',
-        'magento/module-adobe-stock-asset':          '1.0.2-p1',
-        'magento/module-adobe-stock-asset-api':      '1.0.2-p1',
-        'magento/module-adobe-stock-client':         '1.0.2-p1',
-        'magento/module-adobe-stock-client-api':     '1.0.2-p1',
-        'magento/module-adobe-stock-image-api':      '1.0.2-p1',
+        'magento/module-adobe-ims':                  '1.0.2',
+        'magento/module-adobe-ims-api':              '1.0.2',
+        'magento/module-adobe-stock-admin-ui':       '1.0.2',
+        'magento/module-adobe-stock-asset':          '1.0.2',
+        'magento/module-adobe-stock-asset-api':      '1.0.2',
+        'magento/module-adobe-stock-client':         '1.0.2',
+        'magento/module-adobe-stock-client-api':     '1.0.2',
+        'magento/module-adobe-stock-image-api':      '1.0.2',
         'magento/module-adobe-stock-image':          '1.0.2-p2',
         'magento/module-adobe-stock-image-admin-ui': '1.0.3-p2',
       },


### PR DESCRIPTION
Previously, all packages where pinned to patch versions in release 1.0.3-p2, even though only some of them should have.  
This caused the following release 1.0.3-p3 to fail, as some of the packages there now really used patch versions used for 1.0.3-p2.