### PR TITLE
Dockerfile: Run npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN chmod +x /usr/local/bin/install-php-extensions && \
 WORKDIR /generate-repo
 
 COPY . /generate-repo
+RUN cd /generate-repo && npm install
+
 RUN chmod -R 0777 /satis/views
 
 RUN mkdir /generate-repo/repositories && chmod 0777 /generate-repo/repositories && chmod -R 0777 /satis/vendor/composer


### PR DESCRIPTION
The application depends on runtime JS dependencies, such as `parse-options`. These dependencies are nicely declared in package.json, but still need to be installed in the Docker image :).