### PR TITLE
mage-os/generate-mirror-repo-js#75 remove chalk for integrity checker…

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -55,9 +55,6 @@ jobs:
           php-version: ${{ matrix.php }}
           sample-data: 'true'
 
-      - name: Install npm dependencies
-        run: npm install
-
       # Integrity checks
       - run: node src/integrity-test/validate-package-versions-match.js ${{ github.workspace }}/mageos/vendor ${{ github.workspace }}/magento/vendor
         name: Package Versions Validate

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "chalk": "^4.1.2",
         "compare-versions": "^4.1.3",
         "isomorphic-git": "^1.10.4",
         "jszip": "^3.7.1",
@@ -1175,6 +1174,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1433,6 +1433,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1510,6 +1511,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1520,7 +1522,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2044,6 +2047,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3974,6 +3978,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "author": "Vinai Kopp",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "chalk": "^4.1.2",
     "compare-versions": "^4.1.3",
     "isomorphic-git": "^1.10.4",
     "jszip": "^3.7.1",

--- a/src/integrity-test/validate-package-versions-match.js
+++ b/src/integrity-test/validate-package-versions-match.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const chalk = require('chalk');
 const path = require('path');
 
 /**
@@ -133,13 +132,13 @@ function comparePackages(obj1, obj2) {
  */
 function displayDiffs(diffs, originName, targetName) {
   Object.keys(diffs).forEach(packageName => {
-    console.log(chalk.bold(packageName));
+    console.log('\x1b[1m' + packageName + '\x1b[0m');
 
     diffs[packageName].forEach(diff => {
-      const section = chalk.cyan(diff.section);
-      const key = chalk.green(diff.key);
-      const value1 = diff.value1 ? chalk.red(diff.value1) : chalk.gray('undefined');
-      const value2 = diff.value2 ? chalk.blue(diff.value2) : chalk.gray('undefined');
+      const section = '\x1b[36m' + diff.section + '\x1b[0m';
+      const key = '\x1b[32m' + diff.key + '\x1b[0m';
+      const value1 = diff.value1 ? '\x1b[31m' + diff.value1 + '\x1b[0m' : '\x1b[90m' + 'undefined' + '\x1b[0m';
+      const value2 = diff.value2 ? '\x1b[34m' + diff.value2 + '\x1b[0m' : '\x1b[90m' + 'undefined' + '\x1b[0m';
 
       console.log(`  ${section}:
     package: ${key}
@@ -168,7 +167,7 @@ try {
     process.exit(1);
   }
 
-  console.log(chalk.green('Done. No differences found.'));
+  console.log('\x1b[32m' + 'Done. No differences found.' + '\x1b[0m');
 } catch (error) {
   console.error(error.message);
   process.exit(1);


### PR DESCRIPTION
ref: mage-os/generate-mirror-repo-js#75  

Remove `chalk` as it is not mandatory here and adds additional dependencies.