### PR TITLE
fix: tags with -dev suffix generate incompatible nightly version

### DIFF
--- a/src/release-branch-build-tools.js
+++ b/src/release-branch-build-tools.js
@@ -83,7 +83,9 @@ async function getPackageVersionsForBuildInstructions(buildInstructions, suffix)
 function addSuffixToVersion(version, buildSuffix) {
   const pos = version.indexOf('-');
   if (pos !== -1) {
-    return `${version.slice(0, pos)}${version.slice(pos)}${buildSuffix}`
+    const suffix = version.slice(pos)
+    // dev is special. composer/semver parser throws an exception if the buildSuffix is appended without a '+'
+    return `${version.slice(0, pos)}${suffix === '-dev' ? '-dev+' : suffix}${buildSuffix}`
   }
   return `${version}-a${buildSuffix || 'lpha'}`
 }

--- a/tests/release-branch-build-tools.test.js
+++ b/tests/release-branch-build-tools.test.js
@@ -13,6 +13,7 @@ test('It calculates the version', () => {
   expect(sut.calcNightlyBuildPackageBaseVersion('103.0.2.1')).toBe('103.0.2.2');
   expect(sut.calcNightlyBuildPackageBaseVersion('v103.0.2.1')).toBe('v103.0.2.2');
   expect(sut.calcNightlyBuildPackageBaseVersion('0.4.0-beta1')).toBe('0.4.0.1-beta1');
+  expect(sut.calcNightlyBuildPackageBaseVersion('1.2.0-dev')).toBe('1.2.0.1-dev');
 });
 
 
@@ -22,6 +23,16 @@ test('It updates every version in the input package->version map', () => {
     'foo/bar': '103.0.2'
   }, '20220703')).toEqual({
     'foo/bar': '103.0.2.1-a20220703'
+  })
+  expect(sut.transformVersionsToNightlyBuildVersions({
+    'foo/bar': '1.2.0-dev'
+  }, '20220703')).toEqual({
+    'foo/bar': '1.2.0.1-dev+20220703'
+  })
+  expect(sut.transformVersionsToNightlyBuildVersions({
+    'foo/bar': '1.2.0-beta1'
+  }, '20220703')).toEqual({
+    'foo/bar': '1.2.0.1-beta120220703'
   })
   expect(sut.transformVersionsToNightlyBuildVersions({
     'foo/bar': '103.0.2',


### PR DESCRIPTION
Fix satis error parsing nightly package versions based on tags with a `-dev` suffix, for example `1.0.2-dev` would lead to `1.2.0.1-dev20230910`.

After this PR is merged, `-dev` suffixes are treated as a special case, and a `+` is inserted between the `dev` and the date stamp: `1.2.0.1-dev+20230910`

Example of a failed build:

https://github.com/mage-os/generate-mirror-repo-js/actions/runs/6136420403/job/16651250823