### PR TITLE
fix: tags with -dev suffix generate incompatible nightly version

### DIFF
--- a/src/release-branch-build-tools.js
+++ b/src/release-branch-build-tools.js
@@ -81,9 +81,9 @@ async function getPackageVersionsForBuildInstructions(buildInstructions, suffix)
 }
 
 function addSuffixToVersion(version, buildSuffix) {
-  const pos = version.indexOf('-');
-  if (pos !== -1) {
-    return `${version.slice(0, pos)}${(version.slice(pos))}${buildSuffix}`
+  const match = version.match(/(?<versions>(?:[\d]+\.?){1,4})(?<suffix>-[^+]+)?(?<legacy>\+.+)?/)
+  if (match) {
+    return `${match.groups.versions}-a${buildSuffix}${match.groups.legacy ? match.groups.legacy : ''}`
   }
   return `${version}-a${buildSuffix || 'lpha'}`
 }
@@ -103,8 +103,9 @@ function calcNightlyBuildPackageBaseVersion(version) {
   if (! version.match(/^v?(?:\d+\.){0,3}\d+(?:-[a-z]\w*|)$/i)) {
     throw Error(`Unable to determine branch release version for input version "${version}"`)
   }
-  const suffix = version.includes('-') ? version.slice(version.indexOf('-')) : '';
-  const versions = version.includes('-') ? version.slice(0, version.indexOf('-')) : version;
+  const pos = version.indexOf('-')
+  const suffix = pos !== -1 ? version.slice(pos + 1) : '';
+  const versions = pos !== -1 ? version.slice(0, pos) : version;
   const parts = versions.split('.');
   if (parts.length < 4) {
     parts.push('1')
@@ -112,9 +113,7 @@ function calcNightlyBuildPackageBaseVersion(version) {
     parts[parts.length - 1]++;
   }
 
-  // The -dev suffix is special.
-  // The composer/semver parser throws an exception, so we prepend the buildSuffix with -alpha if it is dev to alpha-dev
-  return `${parts.join('.')}${suffix === '-dev' ? '-alpha-dev' : suffix}`;
+  return `${parts.join('.')}${suffix ? '-alpha+' + suffix : ''}`;
 }
 
 /**

--- a/tests/release-branch-build-tools.test.js
+++ b/tests/release-branch-build-tools.test.js
@@ -12,28 +12,34 @@ test('It calculates the version', () => {
   expect(sut.calcNightlyBuildPackageBaseVersion('103.0.2')).toBe('103.0.2.1');
   expect(sut.calcNightlyBuildPackageBaseVersion('103.0.2.1')).toBe('103.0.2.2');
   expect(sut.calcNightlyBuildPackageBaseVersion('v103.0.2.1')).toBe('v103.0.2.2');
-  expect(sut.calcNightlyBuildPackageBaseVersion('0.4.0-beta1')).toBe('0.4.0.1-beta1');
-  expect(sut.calcNightlyBuildPackageBaseVersion('1.2.0-dev')).toBe('1.2.0.1-alpha-dev');
+  expect(sut.calcNightlyBuildPackageBaseVersion('0.4.0-beta1')).toBe('0.4.0.1-alpha+beta1');
+  expect(sut.calcNightlyBuildPackageBaseVersion('1.2.0-dev')).toBe('1.2.0.1-alpha+dev');
+  expect(sut.calcNightlyBuildPackageBaseVersion('1.0-dev')).toBe('1.0.1-alpha+dev');
 });
 
 
 test('It updates every version in the input package->version map', () => {
   expect(sut.transformVersionsToNightlyBuildVersions({}, '')).toEqual({})
-  expect(sut.transformVersionsToNightlyBuildVersions({
-    'foo/bar': '103.0.2'
-  }, '20220703')).toEqual({
-    'foo/bar': '103.0.2.1-a20220703'
-  })
-  expect(sut.transformVersionsToNightlyBuildVersions({
-    'foo/bar': '1.2.0-dev'
-  }, '20220703')).toEqual({
-    'foo/bar': '1.2.0.1-alpha-dev20220703'
-  })
-  expect(sut.transformVersionsToNightlyBuildVersions({
-    'foo/bar': '1.2.0-beta1'
-  }, '20220703')).toEqual({
-    'foo/bar': '1.2.0.1-beta120220703'
-  })
+  expect(sut.transformVersionsToNightlyBuildVersions(
+    {'foo/bar': '103.0.2'}, '20220703')
+  ).toEqual(
+    {'foo/bar': '103.0.2.1-a20220703'}
+  )
+  expect(sut.transformVersionsToNightlyBuildVersions(
+    {'foo/bar': '1.2.0-dev'}, '20220705')
+  ).toEqual(
+    {'foo/bar': '1.2.0.1-a20220705+dev'}
+  )
+  expect(sut.transformVersionsToNightlyBuildVersions(
+    {'foo/bar': '1.0-dev'}, '20220703')
+  ).toEqual(
+    {'foo/bar': '1.0.1-a20220703+dev'}
+  )
+  expect(sut.transformVersionsToNightlyBuildVersions(
+    {'foo/bar': '1.2.0-beta1'}, '20220703')
+  ).toEqual(
+    {'foo/bar': '1.2.0.1-a20220703+beta1'}
+  )
   expect(sut.transformVersionsToNightlyBuildVersions({
     'foo/bar': '103.0.2',
     'baz/moo': '103.0.1.2',
@@ -42,8 +48,8 @@ test('It updates every version in the input package->version map', () => {
   }, '20220704')).toEqual({
     'foo/bar': '103.0.2.1-a20220704',
     'baz/moo': '103.0.1.3-a20220704',
-    'moo/qux': '0.3.4.1-beta120220704',
-    'moo/foo': '0.3.4.1-p220220704',
+    'moo/qux': '0.3.4.1-a20220704+beta1',
+    'moo/foo': '0.3.4.1-a20220704+p2',
   })
 });
 


### PR DESCRIPTION
Also enforce alpha stability for nightly build packages.