### PR TITLE
fix: do not delete existing packages on release deploy

### DIFF
--- a/.github/workflows/build-mageos-release.yml
+++ b/.github/workflows/build-mageos-release.yml
@@ -43,7 +43,7 @@ jobs:
       repo: ${{ inputs.repo }}
       remote_dir: ${{ inputs.remote_dir }}
       entrypoint: src/make/mageos-release.js
-      delete: true
+      delete: false
       mageos_release: ${{ inputs.mageos_release }}
       upstream_release: ${{ inputs.upstream_release }}
       publish_tag: ${{ inputs.publish_tag }}


### PR DESCRIPTION
Previously, when a release was made, existing packages in the repository were deleted by rsync.
This caused the Mage-OS 1.0.0 release to be removed when the 1.0.1 packages were deployed to the repository.

With this change, existing packages remain.