### PR TITLE
Set git user credentials before committing

### DIFF
--- a/src/repository/shell-git.js
+++ b/src/repository/shell-git.js
@@ -256,6 +256,8 @@ module.exports = {
   },
   async commit(url, branch, message) {
     const dir = await initRepo(url, branch)
+    await exec(`git config user.email "info@mage-os.org"`, {cwd: dir});
+    await exec(`git config user.name "Mage-OS CI"`, {cwd: dir});
     await exec(`git commit --no-gpg-sign -m'${ (message || '').replaceAll("'", '"') }'`, {cwd: dir})
     return dir
   },


### PR DESCRIPTION
Previously this was only done before tagging a commit, but it also has to be done before a commit.