### PR TITLE
feat: use composer.json version if found instead of exact constructed constraint

### DIFF
--- a/bin/find-composer-packages.php
+++ b/bin/find-composer-packages.php
@@ -24,6 +24,15 @@ if (! file_exists($argv[1])) {
 }
 
 $loader = require($argv[1]);
+$rootComposerFile = realpath(dirname($argv[1]) . '/../composer.json');
+
+if (! file_exists($rootComposerFile)) {
+    fwrite(STDERR, sprintf("ERROR: Unable to find root composer.json file \"%s\"\n", $rootComposerFile));
+    exit(2);
+}
+
+$rootComposerConfig = json_decode(file_get_contents($rootComposerFile), true);
+
 
 // Get length of file path (returned by $loader) up to package dir inside composer
 $needle = 'vendor/composer/../';
@@ -62,9 +71,14 @@ while (!feof(STDIN)) {
             continue;
         }
         try {
-            $version = \Composer\InstalledVersions::getVersion($package);
+            $depVersion = $rootComposerConfig['require'][$package]
+                ?? $rootComposerConfig['require-dev'][$package]
+                ?? null;
+            if ($depVersion === null) {
+                $version = \Composer\InstalledVersions::getVersion($package);
+                $depVersion = substr($version, 0, strrpos($version, '.'));
+            }
             $done[$package] = true;
-            $depVersion = substr($version, 0, strrpos($version, '.'));
             echo "\"$package\": \"^$depVersion\"\n";
         } catch (OutOfBoundsException $exception) {
             // ignore package


### PR DESCRIPTION
Previously, all base package dependency version constraints were constructed based on the installed version.
However, this lead to issues where a version range like `^3.2, <3.6` didn't get applied to the generated composer.json file, which lead to dependency version conflicts with other packages.

For example:
```
    - mage-os/magento2-base 1.0.2 requires php-amqplib/php-amqplib ^3.6.1 -> satisfiable by php-amqplib/php-amqplib[v3.6.1, v3.6.2].
    - Only one of these can be installed: videlalvaro/php-amqplib[v2.0.0, ..., v2.12.3, v3.0.0, ..., v3.6.2], php-amqplib/php-amqplib[v3.2.0, ..., v3.6.2]. php-amqplib/php-amqplib replaces videlalvaro/php-amqplib and thus cannot coexist with it.
    - mage-os/framework-amqp 1.0.2 requires php-amqplib/php-amqplib ~3.2.0 -> satisfiable by php-amqplib/php-amqplib[v3.2.0].
    - mage-os/product-community-edition 1.0.2 requires mage-os/framework-amqp 1.0.2 -> satisfiable by mage-os/framework-amqp[1.0.2].
    - mage-os/product-community-edition 1.0.2 requires mage-os/magento2-base 1.0.2 -> satisfiable by mage-os/magento2-base[1.0.2].
    - Root composer.json requires mage-os/product-community-edition 1.0.2 -> satisfiable by mage-os/product-community-edition[1.0.2].
```