### PR TITLE
fix: handle undefined reference caused by no tags on `commerce-data-export`

### DIFF
--- a/src/release-branch-build-tools.js
+++ b/src/release-branch-build-tools.js
@@ -25,8 +25,8 @@ async function getPackagesForBuildInstruction(instructions) {
 
 
   // use the latest tag in branch ref
-  const baseVersionsOnRef = await getLatestTag(repoUrl);
-  console.log(`Basing ${repoUrl} package versions on those from tag ${baseVersionsOnRef}`);
+  const baseVersionsOnRef = await getLatestTag(repoUrl) || instructions.ref || 'HEAD';
+  console.log(`Basing ${repoUrl} package versions on those from reference ${baseVersionsOnRef}`);
 
   for (const packageDir of (instructions.packageDirs || [])) {
     const {label, dir, excludes} = Object.assign({excludes: []}, packageDir);

--- a/src/repository/shell-git.js
+++ b/src/repository/shell-git.js
@@ -55,14 +55,14 @@ function trimDir(dir) {
  * @param {String} ref
  */
 function validateRefIsSecure(ref) {
-  if (ref.substring(0, 1) === '-' || ref.includes(' ') || ref.includes('`') || ref.includes('$')) {
+  if (!ref || ref.substring(0, 1) === '-' || ref.includes(' ') || ref.includes('`') || ref.includes('$')) {
     throw new Error(`Rejecting the ref "${ref}" as potentially insecure`)
   }
   return ref;
 }
 
 function validateBranchIsSecure(branch) {
-  if (branch.substring(0, 1) === '-' || branch.includes(' ') || branch.includes('`') || branch.includes('$')) {
+  if (!branch || branch.substring(0, 1) === '-' || branch.includes(' ') || branch.includes('`') || branch.includes('$')) {
     throw new Error(`Rejecting the branch "${branch}" as potentially insecure`)
   }
   return branch;


### PR DESCRIPTION
Nightly build is currently failing:

```
TypeError: Cannot read properties of undefined (reading 'substring')
    at validateRefIsSecure (/home/runner/work/generate-mirror-repo-js/generate-mirror-repo-js/src/repository/shell-git.js:58:11)
    at Object.listFolders (/home/runner/work/generate-mirror-repo-js/generate-mirror-repo-js/src/repository/shell-git.js:188:5)
    at Object.listFolders (/home/runner/work/generate-mirror-repo-js/generate-mirror-repo-js/src/repository.js:12:16)
    at findModulesToBuild (/home/runner/work/generate-mirror-repo-js/generate-mirror-repo-js/src/package-modules.js:406:30)
    at determinePackagesForRef (/home/runner/work/generate-mirror-repo-js/generate-mirror-repo-js/src/package-modules.js:191:25)
    at getPackagesForBuildInstruction (/home/runner/work/generate-mirror-repo-js/generate-mirror-repo-js/src/release-branch-build-tools.js:34:23)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async getPackageVersionsForBuildInstructions (/home/runner/work/generate-mirror-repo-js/generate-mirror-repo-js/src/release-branch-build-tools.js:[78](https://github.com/mage-os/generate-mirror-repo-js/actions/runs/9826601206/job/27128255000#step:8:79):29)
    at async processBuildInstructions (/home/runner/work/generate-mirror-repo-js/generate-mirror-repo-js/src/release-branch-build-tools.js:1[79](https://github.com/mage-os/generate-mirror-repo-js/actions/runs/9826601206/job/27128255000#step:8:80):27)
Error: Process completed with exit code 1.
```

This is caused by https://github.com/mage-os/mirror-commerce-data-export not having any tags. This PR makes some changes to cover that:

1. If repo has no tag, fall back to the defined `ref` (default branch here). If there is no `ref` in the package config, fall back to `HEAD`. _(*I am concerned about what side effects that might have -- but since all modules to date have had tags other than this one, I don't think any other code paths will trigger this.)_
2. If `validateRefIsSecure` or `validateBranchIsSecure` is called with a falsey value (undefined), throw error rather than attempt string comparisons.