### PR TITLE
chore: add rhoerr as an authorized deployer

### DIFF
--- a/.github/workflows/build-mageos-release.yml
+++ b/.github/workflows/build-mageos-release.yml
@@ -39,7 +39,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml
     name: "generate & deploy"
-    if: contains('["vinai","mage-os-ci"]', github.actor)
+    if: contains('["vinai", "rhoerr", "mage-os-ci"]', github.actor)
     with:
       repo: ${{ inputs.repo }}
       remote_dir: ${{ inputs.remote_dir }}


### PR DESCRIPTION
The `build-mageos-release` workflow is restricted to specific enumerated users. This would add me as one of them, if permitted, for the purpose of managing the Mage-OS 1.0.2 release.