### PR TITLE
fix: set package replace value by original package name

### DIFF
--- a/src/release-build-tools.js
+++ b/src/release-build-tools.js
@@ -169,14 +169,17 @@ function updateComposerPluginConfigForMageOs(composerConfig, vendor) {
  * This also happens for the "replace" section, before the given replaceVersionMap is merged.
  */
 function updateComposerConfigFromMagentoToMageOs(composerConfig, releaseVersion, replaceVersionMap, vendor) {
+  const originalPackageName = composerConfig.name
+
   composerConfig.version = releaseVersion
   composerConfig.name = setMageOsVendor(composerConfig.name, vendor)
+  
   updateComposerDepsFromMagentoToMageOs(composerConfig, vendor)
   updateComposerDepsVersionForMageOs(composerConfig, releaseVersion, vendor)
   updateComposerPluginConfigForMageOs(composerConfig, vendor)
 
-  if (replaceVersionMap[composerConfig.name]) {
-    composerConfig.replace = {[composerConfig.name]: replaceVersionMap[composerConfig.name]}
+  if (replaceVersionMap[originalPackageName]) {
+    composerConfig.replace = {[originalPackageName]: replaceVersionMap[originalPackageName]}
   }
 }
 


### PR DESCRIPTION
Fixes a regression in #154 where package name gets changed from `magento/...` to `{vendor}/...` before checking it against the `replaceVersionMap`. This causes it to find no match, because `replaceVersionMap` contains only `magento/...` package names.

This fixes it by recording the original package name before `composer.name = setMageOsVendor(...`, and using that for the map check.