### PR TITLE
chore: remove commerce-data-export packages from nightly builds

### DIFF
--- a/src/build-config/mageos-nightly-build-config.js
+++ b/src/build-config/mageos-nightly-build-config.js
@@ -48,11 +48,10 @@ const branchBuildConfig = {
     repoUrl: 'https://github.com/mage-os/mageos-magento-composer-installer.git',
     ref: 'master',
   },
-  // Keep disabled until repo is set up and integrated into upstream synchronization
-  // 'composer': {
-  //   repoUrl: 'https://github.com/mage-os/mageos-composer.git',
-  //   ref: 'develop',
-  // },
+  'composer': {
+    repoUrl: 'https://github.com/mage-os/mageos-composer.git',
+    ref: 'develop',
+  },
   'composer-root-update-plugin': {
     repoUrl: 'https://github.com/mage-os/mageos-composer-root-update-plugin.git',
     ref: 'develop',
@@ -65,10 +64,11 @@ const branchBuildConfig = {
     repoUrl: 'https://github.com/mage-os/mageos-magento2-sample-data.git',
     ref: '2.4-develop',
   },
-  'commerce-data-export': {
-    repoUrl: 'https://github.com/mage-os/mageos-commerce-data-export.git',
-    ref: 'main'
-  },
+  // Keep disabled until someone takes up maintenance of commerce-data-export tags
+  // 'commerce-data-export': {
+  //   repoUrl: 'https://github.com/mage-os/mageos-commerce-data-export.git',
+  //   ref: 'main'
+  // },
   'magento-coding-standard': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-coding-standard.git',
     ref: 'develop'

--- a/src/build-config/upstream-nightly-build-config.js
+++ b/src/build-config/upstream-nightly-build-config.js
@@ -64,10 +64,11 @@ const branchBuildConfig = {
     repoUrl: 'https://github.com/mage-os/mirror-magento2-sample-data.git',
     ref: '2.4-develop',
   },
-  'commerce-data-export': {
-    repoUrl: 'https://github.com/mage-os/mirror-commerce-data-export.git',
-    ref: 'main'
-  },
+  // Keep disabled until someone takes up maintenance of commerce-data-export tags
+  // 'commerce-data-export': {
+  //   repoUrl: 'https://github.com/mage-os/mirror-commerce-data-export.git',
+  //   ref: 'main'
+  // },
   'magento-coding-standard': {
     repoUrl: 'https://github.com/mage-os/mirror-magento-coding-standard.git',
     ref: 'develop'


### PR DESCRIPTION
Fixes nightly builds being broken by `commerce-data-export`'s lack of tags, by removing it until such a time as someone takes on management of those packages.

Since the packages are not included in Magento Open Source and are not currently included in our mirrors or releases, this will not be a breaking change.


I also enabled `mage-os/mageos-composer` for the Mage-OS nightlies, because that repo is fully set up and synced at this point.