### PR TITLE
chore: add Mage-OS 1.0.3 release history

### DIFF
--- a/.github/actions/checkout-magento/action.yml
+++ b/.github/actions/checkout-magento/action.yml
@@ -18,14 +18,14 @@ inputs:
   composer-version:
     description: 'The version of Composer to use.'
     required: true
-    default: '1'
+    default: '2'
   composer-auth:
     description: 'Composer authentication object.'
     required: false
   php-version:
     description: 'The version of PHP to use.'
     required: true
-    default: '8.1'
+    default: '8.3'
   sample-data:
     description: 'Whether or not to install sample data.'
     required: true

--- a/resource/history/mage-os/magento2-base/1.0.3.json
+++ b/resource/history/mage-os/magento2-base/1.0.3.json
@@ -1,0 +1,579 @@
+{
+  "name": "mage-os/magento2-base",
+  "description": "Magento 2 Base (Community Edition)",
+  "type": "magento2-component",
+  "license": [
+    "OSL-3.0",
+    "AFL-3.0"
+  ],
+  "version": "1.0.3",
+  "require": {
+    "colinmollenhour/credis": "^1.15",
+    "composer/composer": "^2.0, !=2.2.16",
+    "composer/semver": "^3.4.0",
+    "elasticsearch/elasticsearch": "~7.17.0 || ~8.5.0",
+    "friendsofphp/php-cs-fixer": "^3.22",
+    "laminas/laminas-code": "^4.13",
+    "laminas/laminas-eventmanager": "^3.11",
+    "laminas/laminas-file": "^2.13",
+    "laminas/laminas-http": "^2.15",
+    "laminas/laminas-mail": "^2.16",
+    "laminas/laminas-mime": "^2.9",
+    "laminas/laminas-modulemanager": "^2.11",
+    "laminas/laminas-mvc": "^3.6",
+    "laminas/laminas-servicemanager": "^3.16",
+    "laminas/laminas-soap": "^2.10",
+    "laminas/laminas-stdlib": "^3.11",
+    "laminas/laminas-uri": "^2.9",
+    "laminas/laminas-validator": "^2.23",
+    "lusitanian/oauth": "^0.8",
+    "mage-os/composer": "1.0.3",
+    "mage-os/zend-cache": "1.0.3",
+    "mage-os/zend-db": "1.0.3",
+    "monolog/monolog": "^2.7",
+    "pelago/emogrifier": "^7.0",
+    "php-amqplib/php-amqplib": "^3.2",
+    "phpmd/phpmd": "^2.12",
+    "phpunit/php-file-iterator": "^3.0.6",
+    "phpunit/phpunit": "^9.5",
+    "psr/log": "^2 || ^3",
+    "sebastian/phpcpd": "^6.0",
+    "symfony/console": "^6.4",
+    "symfony/filesystem": "^6.4.0",
+    "symfony/finder": "^6.4",
+    "symfony/http-foundation": "^6.4.2",
+    "symfony/polyfill": "^1.28.0",
+    "symfony/process": "^6.4",
+    "webonyx/graphql-php": "^15.0"
+  },
+  "conflict": {
+    "gene/bluefoot": "*"
+  },
+  "replace": {
+    "trentrichardson/jquery-timepicker-addon": "1.4.3",
+    "components/jquery": "1.11.0",
+    "components/jqueryui": "1.10.4",
+    "twbs/bootstrap": "3.1.0",
+    "tinymce/tinymce": "3.4.7"
+  },
+  "extra": {
+    "chmod": [
+      {
+        "mask": "0755",
+        "path": "bin/magento"
+      }
+    ],
+    "component_paths": {
+      "components/jquery": [
+        "lib/web/jquery.js",
+        "lib/web/jquery/jquery.min.js"
+      ],
+      "components/jqueryui": "lib/web/jquery/jquery-ui.js",
+      "tinymce/tinymce": "lib/web/tiny_mce_5",
+      "trentrichardson/jquery-timepicker-addon": "lib/web/jquery/jquery-ui-timepicker-addon.js",
+      "twbs/bootstrap": "lib/web/jquery/jquery.tabs.js"
+    },
+    "map": [
+      [
+        ".editorconfig",
+        ".editorconfig"
+      ],
+      [
+        ".htaccess",
+        ".htaccess"
+      ],
+      [
+        ".htaccess.sample",
+        ".htaccess.sample"
+      ],
+      [
+        ".php-cs-fixer.dist.php",
+        ".php-cs-fixer.dist.php"
+      ],
+      [
+        ".user.ini",
+        ".user.ini"
+      ],
+      [
+        "CHANGELOG.md",
+        "CHANGELOG.md"
+      ],
+      [
+        "COPYING.txt",
+        "COPYING.txt"
+      ],
+      [
+        "Gruntfile.js.sample",
+        "Gruntfile.js.sample"
+      ],
+      [
+        "LICENSE.txt",
+        "LICENSE.txt"
+      ],
+      [
+        "LICENSE_AFL.txt",
+        "LICENSE_AFL.txt"
+      ],
+      [
+        "SECURITY.md",
+        "SECURITY.md"
+      ],
+      [
+        "app/.htaccess",
+        "app/.htaccess"
+      ],
+      [
+        "app/autoload.php",
+        "app/autoload.php"
+      ],
+      [
+        "app/bootstrap.php",
+        "app/bootstrap.php"
+      ],
+      [
+        "app/design/adminhtml/Magento",
+        "app/design/adminhtml/Magento"
+      ],
+      [
+        "app/design/frontend/Magento",
+        "app/design/frontend/Magento"
+      ],
+      [
+        "app/etc/NonComposerComponentRegistration.php",
+        "app/etc/NonComposerComponentRegistration.php"
+      ],
+      [
+        "app/etc/db_schema.xml",
+        "app/etc/db_schema.xml"
+      ],
+      [
+        "app/etc/di.xml",
+        "app/etc/di.xml"
+      ],
+      [
+        "app/etc/registration_globlist.php",
+        "app/etc/registration_globlist.php"
+      ],
+      [
+        "auth.json.sample",
+        "auth.json.sample"
+      ],
+      [
+        "bin/.htaccess",
+        "bin/.htaccess"
+      ],
+      [
+        "bin/magento",
+        "bin/magento"
+      ],
+      [
+        "dev/.htaccess",
+        "dev/.htaccess"
+      ],
+      [
+        "dev/tests/.gitignore",
+        "dev/tests/.gitignore"
+      ],
+      [
+        "dev/tests/acceptance",
+        "dev/tests/acceptance"
+      ],
+      [
+        "dev/tests/api-functional/.gitignore",
+        "dev/tests/api-functional/.gitignore"
+      ],
+      [
+        "dev/tests/api-functional/_files",
+        "dev/tests/api-functional/_files"
+      ],
+      [
+        "dev/tests/api-functional/allure",
+        "dev/tests/api-functional/allure"
+      ],
+      [
+        "dev/tests/api-functional/config",
+        "dev/tests/api-functional/config"
+      ],
+      [
+        "dev/tests/api-functional/framework",
+        "dev/tests/api-functional/framework"
+      ],
+      [
+        "dev/tests/api-functional/isolate_gql.txt",
+        "dev/tests/api-functional/isolate_gql.txt"
+      ],
+      [
+        "dev/tests/api-functional/isolate_rest.txt",
+        "dev/tests/api-functional/isolate_rest.txt"
+      ],
+      [
+        "dev/tests/api-functional/phpunit_graphql.xml.dist",
+        "dev/tests/api-functional/phpunit_graphql.xml.dist"
+      ],
+      [
+        "dev/tests/api-functional/phpunit_rest.xml.dist",
+        "dev/tests/api-functional/phpunit_rest.xml.dist"
+      ],
+      [
+        "dev/tests/api-functional/phpunit_soap.xml.dist",
+        "dev/tests/api-functional/phpunit_soap.xml.dist"
+      ],
+      [
+        "dev/tests/api-functional/testsuite/Magento",
+        "dev/tests/api-functional/testsuite/Magento"
+      ],
+      [
+        "dev/tests/config",
+        "dev/tests/config"
+      ],
+      [
+        "dev/tests/error_handler.php",
+        "dev/tests/error_handler.php"
+      ],
+      [
+        "dev/tests/integration/.gitignore",
+        "dev/tests/integration/.gitignore"
+      ],
+      [
+        "dev/tests/integration/_files",
+        "dev/tests/integration/_files"
+      ],
+      [
+        "dev/tests/integration/allure",
+        "dev/tests/integration/allure"
+      ],
+      [
+        "dev/tests/integration/bin",
+        "dev/tests/integration/bin"
+      ],
+      [
+        "dev/tests/integration/etc",
+        "dev/tests/integration/etc"
+      ],
+      [
+        "dev/tests/integration/framework",
+        "dev/tests/integration/framework"
+      ],
+      [
+        "dev/tests/integration/isolate.txt",
+        "dev/tests/integration/isolate.txt"
+      ],
+      [
+        "dev/tests/integration/phpunit.xml.dist",
+        "dev/tests/integration/phpunit.xml.dist"
+      ],
+      [
+        "dev/tests/integration/testsuite/Magento",
+        "dev/tests/integration/testsuite/Magento"
+      ],
+      [
+        "dev/tests/integration/tmp",
+        "dev/tests/integration/tmp"
+      ],
+      [
+        "dev/tests/js",
+        "dev/tests/js"
+      ],
+      [
+        "dev/tests/setup-integration",
+        "dev/tests/setup-integration"
+      ],
+      [
+        "dev/tests/static/.gitignore",
+        "dev/tests/static/.gitignore"
+      ],
+      [
+        "dev/tests/static/allure",
+        "dev/tests/static/allure"
+      ],
+      [
+        "dev/tests/static/framework",
+        "dev/tests/static/framework"
+      ],
+      [
+        "dev/tests/static/get_github_changes.php",
+        "dev/tests/static/get_github_changes.php"
+      ],
+      [
+        "dev/tests/static/phpunit-all.xml.dist",
+        "dev/tests/static/phpunit-all.xml.dist"
+      ],
+      [
+        "dev/tests/static/phpunit.xml.dist",
+        "dev/tests/static/phpunit.xml.dist"
+      ],
+      [
+        "dev/tests/static/testsuite/Magento",
+        "dev/tests/static/testsuite/Magento"
+      ],
+      [
+        "dev/tests/static/tmp",
+        "dev/tests/static/tmp"
+      ],
+      [
+        "dev/tests/unit/.gitignore",
+        "dev/tests/unit/.gitignore"
+      ],
+      [
+        "dev/tests/unit/allure",
+        "dev/tests/unit/allure"
+      ],
+      [
+        "dev/tests/unit/framework",
+        "dev/tests/unit/framework"
+      ],
+      [
+        "dev/tests/unit/phpunit.xml.dist",
+        "dev/tests/unit/phpunit.xml.dist"
+      ],
+      [
+        "dev/tests/unit/tmp",
+        "dev/tests/unit/tmp"
+      ],
+      [
+        "dev/tests/utils",
+        "dev/tests/utils"
+      ],
+      [
+        "dev/tests/varnish",
+        "dev/tests/varnish"
+      ],
+      [
+        "dev/tools",
+        "dev/tools"
+      ],
+      [
+        "generated",
+        "generated"
+      ],
+      [
+        "grunt-config.json.sample",
+        "grunt-config.json.sample"
+      ],
+      [
+        "lib/.htaccess",
+        "lib/.htaccess"
+      ],
+      [
+        "lib/internal/GnuFreeFont",
+        "lib/internal/GnuFreeFont"
+      ],
+      [
+        "lib/internal/LinLibertineFont",
+        "lib/internal/LinLibertineFont"
+      ],
+      [
+        "lib/web/blank.html",
+        "lib/web/blank.html"
+      ],
+      [
+        "lib/web/chartjs",
+        "lib/web/chartjs"
+      ],
+      [
+        "lib/web/css",
+        "lib/web/css"
+      ],
+      [
+        "lib/web/extjs",
+        "lib/web/extjs"
+      ],
+      [
+        "lib/web/fonts",
+        "lib/web/fonts"
+      ],
+      [
+        "lib/web/fotorama",
+        "lib/web/fotorama"
+      ],
+      [
+        "lib/web/i18n",
+        "lib/web/i18n"
+      ],
+      [
+        "lib/web/images",
+        "lib/web/images"
+      ],
+      [
+        "lib/web/jquery",
+        "lib/web/jquery"
+      ],
+      [
+        "lib/web/jquery.js",
+        "lib/web/jquery.js"
+      ],
+      [
+        "lib/web/js-cookie",
+        "lib/web/js-cookie"
+      ],
+      [
+        "lib/web/js-storage",
+        "lib/web/js-storage"
+      ],
+      [
+        "lib/web/knockoutjs",
+        "lib/web/knockoutjs"
+      ],
+      [
+        "lib/web/legacy-build.min.js",
+        "lib/web/legacy-build.min.js"
+      ],
+      [
+        "lib/web/less",
+        "lib/web/less"
+      ],
+      [
+        "lib/web/lib",
+        "lib/web/lib"
+      ],
+      [
+        "lib/web/mage",
+        "lib/web/mage"
+      ],
+      [
+        "lib/web/magnifier",
+        "lib/web/magnifier"
+      ],
+      [
+        "lib/web/matchMedia.js",
+        "lib/web/matchMedia.js"
+      ],
+      [
+        "lib/web/moment-timezone-with-data.js",
+        "lib/web/moment-timezone-with-data.js"
+      ],
+      [
+        "lib/web/moment.js",
+        "lib/web/moment.js"
+      ],
+      [
+        "lib/web/prototype",
+        "lib/web/prototype"
+      ],
+      [
+        "lib/web/requirejs",
+        "lib/web/requirejs"
+      ],
+      [
+        "lib/web/scriptaculous",
+        "lib/web/scriptaculous"
+      ],
+      [
+        "lib/web/spacer.gif",
+        "lib/web/spacer.gif"
+      ],
+      [
+        "lib/web/tiny_mce_5",
+        "lib/web/tiny_mce_5"
+      ],
+      [
+        "lib/web/underscore.js",
+        "lib/web/underscore.js"
+      ],
+      [
+        "lib/web/varien",
+        "lib/web/varien"
+      ],
+      [
+        "lib/web/vimeo",
+        "lib/web/vimeo"
+      ],
+      [
+        "nginx.conf.sample",
+        "nginx.conf.sample"
+      ],
+      [
+        "package.json.sample",
+        "package.json.sample"
+      ],
+      [
+        "phpserver",
+        "phpserver"
+      ],
+      [
+        "pub/.htaccess",
+        "pub/.htaccess"
+      ],
+      [
+        "pub/.user.ini",
+        "pub/.user.ini"
+      ],
+      [
+        "pub/cron.php",
+        "pub/cron.php"
+      ],
+      [
+        "pub/errors",
+        "pub/errors"
+      ],
+      [
+        "pub/get.php",
+        "pub/get.php"
+      ],
+      [
+        "pub/health_check.php",
+        "pub/health_check.php"
+      ],
+      [
+        "pub/index.php",
+        "pub/index.php"
+      ],
+      [
+        "pub/media/.htaccess",
+        "pub/media/.htaccess"
+      ],
+      [
+        "pub/media/custom_options",
+        "pub/media/custom_options"
+      ],
+      [
+        "pub/media/customer/.htaccess",
+        "pub/media/customer/.htaccess"
+      ],
+      [
+        "pub/media/customer_address",
+        "pub/media/customer_address"
+      ],
+      [
+        "pub/media/downloadable/.htaccess",
+        "pub/media/downloadable/.htaccess"
+      ],
+      [
+        "pub/media/import",
+        "pub/media/import"
+      ],
+      [
+        "pub/media/sitemap",
+        "pub/media/sitemap"
+      ],
+      [
+        "pub/media/theme_customization/.htaccess",
+        "pub/media/theme_customization/.htaccess"
+      ],
+      [
+        "pub/opt",
+        "pub/opt"
+      ],
+      [
+        "pub/static/.htaccess",
+        "pub/static/.htaccess"
+      ],
+      [
+        "pub/static.php",
+        "pub/static.php"
+      ],
+      [
+        "setup",
+        "setup"
+      ],
+      [
+        "var/.htaccess",
+        "var/.htaccess"
+      ],
+      [
+        "vendor/.htaccess",
+        "vendor/.htaccess"
+      ]
+    ]
+  }
+}

--- a/resource/history/mage-os/product-community-edition/1.0.3.json
+++ b/resource/history/mage-os/product-community-edition/1.0.3.json
@@ -1,0 +1,7 @@
+{
+  "require": {
+    "mage-os/security-package": "1.0.3",
+    "mage-os/inventory-metapackage": "1.0.3",
+    "mage-os/page-builder": "1.0.3"
+  }
+}

--- a/resource/history/mage-os/project-community-edition/1.0.3.json
+++ b/resource/history/mage-os/project-community-edition/1.0.3.json
@@ -1,0 +1,6 @@
+{
+  "require": {
+    "mage-os/composer-root-update-plugin": "1.0.3",
+    "mage-os/composer-dependency-version-audit-plugin": "1.0.3"
+  }
+}


### PR DESCRIPTION
This adds the release history files for Mage-OS Distribution 1.0.3.

Also bumped versions for the `checkout-magento` action to Composer 2 and PHP 8.3.