### PR TITLE
Add authorized mirror and release deployers

### DIFF
--- a/.github/workflows/build-mageos-release.yml
+++ b/.github/workflows/build-mageos-release.yml
@@ -39,7 +39,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml
     name: "generate & deploy"
-    if: contains('["vinai", "rhoerr", "mage-os-ci"]', github.actor)
+    if: contains('["vinai", "rhoerr", "fballiano", "mage-os-ci"]', github.actor)
     with:
       repo: ${{ inputs.repo }}
       remote_dir: ${{ inputs.remote_dir }}

--- a/.github/workflows/build-upstream-mirror.yml
+++ b/.github/workflows/build-upstream-mirror.yml
@@ -27,7 +27,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml
     name: "generate & deploy"
-    if: contains('["vinai","mage-os-ci"]', github.actor)
+    if: contains('["vinai", "rhoerr", "fballiano", "mage-os-ci"]', github.actor)
     with:
       repo: ${{ inputs.repo }}
       remote_dir: ${{ inputs.remote_dir }}


### PR DESCRIPTION
This PR adds @fballiano as an authorized deployer for Mage-OS releases and mirror deployments, on the basis of joining Mage-OS as Release Manager starting 1 Oct.

It also adds me @rhoerr to the mirror deployer list (missed in #167).