### PR TITLE
Bugfix: FromAsCasing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM composer/satis as build
+FROM composer/satis AS build
 
 RUN apk add nodejs npm jq
 


### PR DESCRIPTION
while running `docker build .` we get 

`- FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)`

This PR fixes it