### PR TITLE
Chore: fix tinymce map

### DIFF
--- a/resource/composer-templates/mage-os/magento2-base/template.json
+++ b/resource/composer-templates/mage-os/magento2-base/template.json
@@ -455,6 +455,10 @@
         "lib/web/tiny_mce_5"
       ],
       [
+        "lib/web/tiny_mce_6",
+        "lib/web/tiny_mce_6"
+      ],
+      [
         "lib/web/underscore.js",
         "lib/web/underscore.js"
       ],

--- a/resource/composer-templates/magento/magento2-base/template.json
+++ b/resource/composer-templates/magento/magento2-base/template.json
@@ -455,6 +455,10 @@
         "lib/web/tiny_mce_5"
       ],
       [
+        "lib/web/tiny_mce_7",
+        "lib/web/tiny_mce_7"
+      ],
+      [
         "lib/web/underscore.js",
         "lib/web/underscore.js"
       ],


### PR DESCRIPTION
The Mage-OS 1.0.5 release needs the tiny_mce_6 package added to the magento2-base module composer template, in order to copy to the proper location on install.

This PR adds that, and also adds tiny_mce_7 to the same for the upstream nightly builds -- because upstream has 7 packaged at this point.