### PR TITLE
feat: add upstream version to metapackage composer.json for runtime use

### DIFF
--- a/src/determine-dependencies.js
+++ b/src/determine-dependencies.js
@@ -79,6 +79,11 @@ module.exports = {
 
         await new Promise(resolve => {
           const classesInPhp = childProcess.spawn('php-classes.phar', [], options);
+          classesInPhp.on('error', error => {
+            if (error.code === 'ENOENT') {
+              console.log('Error: Missing `php-classes.phar`. Please see the README for install directions.');
+            }
+          });
           classesInPhp.on('close', status => resolve());
 
           // Pipe file contents to php-classes.phar separated by a zero byte

--- a/src/make/mageos-release.js
+++ b/src/make/mageos-release.js
@@ -37,6 +37,7 @@ Options:
   --mageosRelease=   Target Mage-OS release version
   --releaseRefsFile= JS file exporting a map with the git repo refs to use for the release
   --upstreamRelease= Upstream Magento Open Source release to use for package compatibility
+  --skipHistory      Skip rebuilding of historic releases
 `);
   process.exit(1);
 }

--- a/src/release-build-tools.js
+++ b/src/release-build-tools.js
@@ -211,7 +211,7 @@ async function buildMageOsProductCommunityEditionMetapackage(releaseVersion, ins
 
           // Add upstreamRelease to composer extra data for reference
           composerConfig.extra = composerConfig.extra || {};
-          composerConfig.extra.magento_version = replaceVersionMap[`${vendor}/product-community-edition`];
+          composerConfig.extra.magento_version = replaceVersionMap['replaceVersionMap']['magento/product-community-edition'];
 
           return composerConfig
         }

--- a/src/release-build-tools.js
+++ b/src/release-build-tools.js
@@ -208,6 +208,11 @@ async function buildMageOsProductCommunityEditionMetapackage(releaseVersion, ins
       [`${vendor}/product-community-edition`]: [
         (composerConfig) => {
           updateComposerConfigFromMagentoToMageOs(composerConfig, releaseVersion, replaceVersionMap, vendor)
+
+          // Add upstreamRelease to composer extra data for reference
+          composerConfig.extra = composerConfig.extra || {};
+          composerConfig.extra.magento_version = replaceVersionMap[`${vendor}/product-community-edition`];
+
           return composerConfig
         }
       ]


### PR DESCRIPTION
This is the build-release portion of changes for https://github.com/mage-os/mageos-magento2/issues/108

Some extensions use version comparison in Magento to determine what code to run. This is a problem for Mage-OS, where we replace Magento's `getVersion()` number (IE 2.4.7) with the Mage-OS version (IE 1.0.5), causing old incompatible code to run.

The idea here is:
* Magento gets the version from composer.lock for `magento/product-community-edition`, via https://github.com/rhoerr/mageos-magento2/blob/7bed30c9ea2b6e31130d4cead3e191871fb9b98e/lib/internal/Magento/Framework/App/ProductMetadata.php#L118
* Mage-OS replaces that version number during our existing build/release process.
* To fix it, we change getVersion to return the equivalent Magento version, and add a separate method to get the Mage-OS version.
* To do that, we have to know what the equivalent upstream Magento version is for a given release.
* To do that, we can store the upstream equivalent version from the build params into the composer metadata for the `mage-os/product-community-edition` metapackage.
* Composer lets us store arbitrary data in `composerConfig.extra`.
* We get the upstream version from the `replaceVersionMap` (package versions for the defined upstream release) for `magento/product-community-edition`, which contains the expected version number, EG 2.4.7-p3.
* We store that on `composerConfig.extra.magento_version`, so that Magento can load that from the lock file at runtime, the same way it gets the metapackage version now.