### PR TITLE
Added documentation on how to build a new mirror release

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ For a practical example [check this PR](https://github.com/mage-os/magento2-base
   date of the previous version (2.4.6-p8) to _one day earlier_ of the release date of the next version.
   [Check this example commit](https://github.com/mage-os/github-actions/pull/262/files#diff-0655b3d6263a5375945b0a6bbab191703f8ee83f9535a48e2871d8afec4cb2fc)
   and this screenshot to better understand what needs to be done:  
-  [TODO INSERT IMAGE FROM GITHUB]
+  <img width=500 src="https://github.com/user-attachments/assets/2860e539-e76e-4c8f-89c6-a8c4f1331778" />
 - Check if `magento-open-source/composite.json` needs updating
   (it only happens when a new "non patch" release is published, like 2.4.8).
 - Now "build" the project with
@@ -197,7 +197,8 @@ the PR will have to be merged on a development branch.
 Then go to the _actions_ for this repo:  and run the
 [build, deploy & check mirror](https://github.com/mage-os/generate-mirror-repo-js/actions/workflows/build-upstream-mirror.yml)
 selecting the new dev branch and the rest of the parameters as shown in this image:  
-[TODO INSERT IMAGE FROM GITHUB]
+<img width="323" src="https://github.com/user-attachments/assets/31eb1eaf-5c2a-4d0b-8475-9e9f7c9239a8" />
+
 
 For a practical example [check this PR](https://github.com/mage-os/generate-mirror-repo-js/pull/191)
 and [this second one to merge the temporary dev branch into `main`](https://github.com/mage-os/generate-mirror-repo-js/pull/194).

--- a/README.md
+++ b/README.md
@@ -123,6 +123,43 @@ Two things are required:
 docker build -t magece/mirror-repo-js .
 ```
 
+## Process of building a new mirror release
+
+A new mirror release gets created when Magento releases a new version.
+The process is composed of a series of steps across 3 repositories of the mage-os organization.
+
+### 1. magento2-base-composer-json
+
+- Fork and clone https://github.com/mage-os/magento2-base-composer-json,
+  then create a new branch that you'll use to create a pull request. 
+- Run the `add-release.sh` script for every release, eg:
+  ```sh
+  ./add-release.sh 2.4.7-p4
+  ./add-release.sh 2.4.6-p9
+  ./add-release.sh 2.4.5-p11
+  ./add-release.sh 2.4.4-p12
+  ```
+- Add, commit and push all the newly created files.
+
+For a practical example [check this PR](https://github.com/mage-os/magento2-base-composer-json/pull/7).
+
+### 2. github-actions
+
+- Fork and clone https://github.com/mage-os/github-actions,
+  then create a new branch that you'll use to create a pull request.
+- Update the supported versions matrix editing
+  [src/versions/magento-open-source/individual.json](https://github.com/mage-os/github-actions/blob/main/supported-version/src/versions/magento-open-source/individual.json).  
+  Remember that, when inserting a new version like 2.4.6-p9, you´ll have to change the _end of life_
+  date of the previous version (2.4.6-p8) to _one day earlier_ of the release date of the next version.
+  [Check this example commit](https://github.com/mage-os/github-actions/pull/262/files#diff-0655b3d6263a5375945b0a6bbab191703f8ee83f9535a48e2871d8afec4cb2fc)
+  and this screenshot to better understand what needs to be done:  
+  [TODO INSERT IMAGE FROM GITHUB]
+  
+
+For a practical example [check this PR](https://github.com/mage-os/github-actions/pull/262).
+
+### 3. generate-mirror-repo-js
+
 ## Copyright 2022 Vinai Kopp, Mage-OS
 
 Distributed under the terms of the 3-Clause BSD Licence.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ docker build -t magece/mirror-repo-js .
 A new mirror release gets created when Magento releases a new version.
 The process is composed of a series of steps across 3 repositories of the mage-os organization.
 
+### 0. Preliminary check
+
+Before starting, make sure that the new tags are merged into every `mage-os/mirror-*` repository
+(eg: https://github.com/mage-os/mirror-magento2).  
+In case it’s not, go to [mage-os/infrastructure](http://github.com/mage-os/infrastructure)
+and run [Sync magento/ org upstream repositories into mirrors for mage-os distribution](https://github.com/mage-os/infrastructure/actions/workflows/sync-upstream-magento.yml)
+action (check branch `main` when running it).
+
 ### 1. magento2-base-composer-json
 
 - Fork and clone https://github.com/mage-os/magento2-base-composer-json,
@@ -154,11 +162,45 @@ For a practical example [check this PR](https://github.com/mage-os/magento2-base
   [Check this example commit](https://github.com/mage-os/github-actions/pull/262/files#diff-0655b3d6263a5375945b0a6bbab191703f8ee83f9535a48e2871d8afec4cb2fc)
   and this screenshot to better understand what needs to be done:  
   [TODO INSERT IMAGE FROM GITHUB]
-  
+- Check if `magento-open-source/composite.json` needs updating
+  (it only happens when a new "non patch" release is published, like 2.4.8).
+- Now "build" the project with
+  - In the root of the project: `npm install`
+  - In the supported-version folder: `npm run build
+- Edit `src/kind/get-currently-supported.spec.ts`
+- Run `npm run test` and make sure that all tests are green.
+- Commit, push and open a PR on mage-os/github-actions.
 
 For a practical example [check this PR](https://github.com/mage-os/github-actions/pull/262).
 
 ### 3. generate-mirror-repo-js
+
+- Fork and clone https://github.com/mage-os/generate-mirror-repo-js,
+  then create a new branch that you'll use to create a pull request.
+- Install latest magento version with  
+  `composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition`
+- "Build" the mirror with  
+  `rm -rf repositories; node src/make/mirror.js --outputDir=build`
+- Download all missing packages with  
+  `./bin/download-missing-packages-from-repo-magento-com.php project-community-edition/composer.lock build resource/additional-packages`
+- Commit and push the new files in `resource/additional-packages`.
+- Copy all the `composer.json` files for all releases with something like
+  ```sh
+  cp ../mageos-magento2-base-composer-json/2.4.7-p4/magento2-base/composer.json resource/history/magento/magento2-base/2.4.7-p4.json
+  cp ../mageos-magento2-base-composer-json/2.4.7-p4/product-community-edition/composer.json resource/history/magento/product-community-edition/2.4.7-p4.json
+  cp ../mageos-magento2-base-composer-json/2.4.7-p4/project-community-edition/composer.json resource/history/magento/project-community-edition/2.4.7-p4.json
+  ```
+- Commit and push all the `composer.json` files.
+
+When creating the PR on `generate-mirror-repo-js`, in order for all the checks to run,
+the PR will have to be merged on a development branch.
+Then go to the _actions_ for this repo:  and run the
+[build, deploy & check mirror](https://github.com/mage-os/generate-mirror-repo-js/actions/workflows/build-upstream-mirror.yml)
+selecting the new dev branch and the rest of the parameters as shown in this image:  
+[TODO INSERT IMAGE FROM GITHUB]
+
+For a practical example [check this PR](https://github.com/mage-os/generate-mirror-repo-js/pull/191)
+and [this second one to merge the temporary dev branch into `main`](https://github.com/mage-os/generate-mirror-repo-js/pull/194).
 
 ## Copyright 2022 Vinai Kopp, Mage-OS
 


### PR DESCRIPTION
This documentation was written during the process of releasing 2.4.7-p4 mirror.

To see a preview of the result: https://github.com/fballiano/mageos-generate-mirror-repo-js/tree/build-mirror?tab=readme-ov-file#process-of-building-a-new-mirror-release