### PR TITLE
Add creatuity/magento2-interceptors as a bundled extension

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder"


### PR DESCRIPTION
I propose adding Creatuity_Interception as a bundled module with the upcoming Mage-OS 1.1.0. https://github.com/creatuity/magento2-interceptors

- It provides a meaningful and quantifiable performance improvement for all Magento Open Source sites, in the area of 10%;
- It is safe and battle tested, having been in frequent production use since 2019, including over 49k composer installs, and including all ParadoxLabs client sites I maintain;
- It is widely known and trusted;
- It is well maintained, with negligible open issues (rare or debatable edge cases).

## Implications
- Mage-OS will have a new `compiled_plugins` cache type to be enabled or disabled on sites (optional opt-in)
- When enabled, compiling will result in interceptors being written into the generated/ folder with explicit calls to each plugin
- Adding or changing plugins during development requires clearing the compiled interceptors
- It changes stack traces for plugins, since they are now called directly, allowing for more direct understanding and debugging of execution paths involving plugins

## Risks
- Minimal: It's widely used and a drop-in replacement for default interceptors.
- [Magento has not merged it to date](https://github.com/magento/magento2/pull/22826) due to the architectural implications on the core. That's not a concern to us, partly because we're not Magento, partly because it's well proven, partly because it's a separate package that's easily disabled.
- There is a report of case-insensitive conflicts between plugins (where one plugin on a class has `pluginname` and another has `pluginName` on the same class, only one will be compiled and executed). I've never seen this situation arise, and would argue it's bad practice in the first place.
- There is a report of inability to disable plugins in one scope but not another. This may have been since resolved in core, and could not be reproduced on 2.4.7.

## Benefits
- 10% improvement in server response times, on average.

## PR
This PR results in the module being added as a pinned require of `mage-os/product-community-edition` like:
```
    "creatuity/magento2-interceptors": "1.3.5",
```
which composer will then require via packagist, like any other third party package (Monolog, Laminas, Symphony, ...).