### PR TITLE
Add mage-os/theme-adminhtml-m137 as a bundled package

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -1,7 +1,9 @@
 {
   "dependencies": {
-    "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
-    "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder"
+    "mage-os/module-theme-adminhtml-switcher": "https://github.com/mage-os-lab/module-theme-adminhtml-switcher.git",
+    "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
+    "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
+    "mage-os/theme-adminhtml-m137": "https://github.com/mage-os-lab/theme-adminhtml-m137.git"
   }
 }

--- a/src/build-config/mageos-release-build-config.js
+++ b/src/build-config/mageos-release-build-config.js
@@ -114,6 +114,214 @@ const releaseBuildConfig = {
     ref: 'release/1.x',
     fromTag: '1.0.0',
   },
+  // 'theme-adminhtml-m137': {
+  //   repoUrl: 'https://github.com/mage-os-lab/theme-adminhtml-m137.git',
+  //   ref: 'main',
+  //   fronTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'theme-adminhtml-m137',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'module-theme-adminhtml-switcher': {
+  //   repoUrl: 'https://github.com/mage-os-lab/module-theme-adminhtml-switcher.git',
+  //   ref: 'main',
+  //   fronTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'module-theme-adminhtml-switcher',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'mageos-async-events-sinks': {
+  //   repoUrl: 'https://github.com/mage-os/mageos-async-events-sinks.git',
+  //   ref: 'main',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'mageos-async-events-sinks',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'mageos-async-events-admin-ui': {
+  //   repoUrl: 'https://github.com/mage-os/mageos-async-events-admin-ui.git',
+  //   ref: 'main',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'mageos-async-events-admin-ui',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // // 'mageos-async-events-azure': {
+  // //   repoUrl: 'https://github.com/mage-os/mageos-async-events-azure.git',
+  // //   ref: 'main',
+  // //   fromTag: '1.0.0',
+  // //   packageDirs: [],
+  // //   packageIndividual: [
+  // //     {
+  // //       label: 'mageos-async-events-azure',
+  // //       dir: ''
+  // //     }
+  // //   ],
+  // //   packageMetaFromDirs: [],
+  // // },
+  // 'mageos-async-events': {
+  //   repoUrl: 'https://github.com/mage-os/mageos-async-events.git',
+  //   ref: '4.x',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'mageos-async-events',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'mageos-async-events-aws': {
+  //   repoUrl: 'https://github.com/mage-os/mageos-async-events-aws.git',
+  //   ref: 'main',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'mageos-async-events-aws',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'mageos-async-events-gcp': {
+  //   repoUrl: 'https://github.com/mage-os/mageos-async-events-gcp.git',
+  //   ref: 'main',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'mageos-async-events-gcp',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'mageos-common-async-events': {
+  //   repoUrl: 'https://github.com/mage-os/mageos-common-async-events.git',
+  //   ref: 'main',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'mageos-common-async-events',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'module-inventory-reservations-grid': {
+  //   repoUrl: 'https://github.com/mage-os-lab/module-inventory-reservations-grid.git',
+  //   ref: 'main',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'module-inventory-reservations-grid',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'module-automatic-translation': {
+  //   repoUrl: 'https://github.com/mage-os-lab/module-automatic-translation.git',
+  //   ref: 'main',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'module-automatic-translation',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'web-installer': {
+  //   repoUrl: 'https://github.com/mage-os-lab/web-installer.git',
+  //   ref: 'main',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'web-installer',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'module-meta-robots-tag': {
+  //   repoUrl: 'https://github.com/mage-os-lab/module-meta-robots-tag.git',
+  //   ref: 'main',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'module-meta-robots-tag',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'module-catalog-data-ai': {
+  //   repoUrl: 'https://github.com/mage-os-lab/module-catalog-data-ai.git',
+  //   ref: 'main',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'module-catalog-data-ai',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'module-pagebuilder-template-import-export': {
+  //   repoUrl: 'https://github.com/mage-os-lab/module-pagebuilder-template-import-export.git',
+  //   ref: 'master',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'module-pagebuilder-template-import-export',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
+  // 'module-admin-assistant': {
+  //   repoUrl: 'https://github.com/mage-os-lab/module-admin-assistant.git',
+  //   ref: 'main',
+  //   fromTag: '1.0.0',
+  //   packageDirs: [],
+  //   packageIndividual: [
+  //     {
+  //       label: 'module-admin-assistant',
+  //       dir: ''
+  //     }
+  //   ],
+  //   packageMetaFromDirs: [],
+  // },
 };
 
 module.exports = {

--- a/src/package-modules.js
+++ b/src/package-modules.js
@@ -120,6 +120,7 @@ function chooseNameAndVersion(magentoName, composerJson, ref, givenVersion) {
 function setDependencyVersions(composerConfig, dependencyVersions, vendor) {
   for (const dependencyType of ['require', 'require-dev', 'suggest']) {
     for (const dep in (composerConfig[dependencyType] || {})) {
+      // @TODO: Allow vendor packages to be flagged as independently packaged. In that case, use the latest tagged version, not the current release or fallback version.
       if (dependencyVersions[dep] || (vendor && dep.startsWith(vendor) && dependencyVersions['*'])) {
         // The "Sample Data version:" prefix is used by sampledata:deploy to identify packages to require.
         // See \Magento\SampleData\Model\Dependency::getSampleDataPackages
@@ -268,6 +269,7 @@ async function createPackageForRef(url, moduleDir, ref, options) {
    *    dependencyVersions: set as {'*': releaseVersion}
    *    => use dependencyVersions
    */
+  // @TODO: Change mageos release version handling for independently packaged packages
   ({
     name,
     version

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,10 +43,11 @@ function mergeBuildConfigs(a, b) {
       repoInstruction[type].map(bx => {
         const idField = bx.dir ? 'dir' : 'label'
         const targetIdx = (a[key]?.[type] || []).findIndex(ax => ax[idField] === bx[idField])
+        a[key] = a[key] || {};
         if (targetIdx > -1) {
           a[key][type][targetIdx] = Object.assign(a[key][type][targetIdx], bx)
         } else {
-          a[key][type].push(bx)
+          a[key][type] = (a[key]?.[type] || []).concat([bx])
         }
       })
       delete b[key][type];


### PR DESCRIPTION
Include https://github.com/mage-os-lab/theme-adminhtml-m137 and https://github.com/mage-os-lab/module-theme-adminhtml-switcher as bundled parts of the next Mage-OS release.

Work in progress. Requires build changes to allow packages like this to be tagged and released separately from Mage-OS itself.