### PR TITLE
Fix: Convert branch names to valid Composer dev-branch format

### DIFF
--- a/src/release-branch-build-tools.js
+++ b/src/release-branch-build-tools.js
@@ -81,6 +81,11 @@ async function getPackageVersionsForBuildInstructions(buildInstructions, suffix)
 }
 
 function addSuffixToVersion(version, buildSuffix) {
+  // Don't add suffix to dev- branch versions
+  if (version.startsWith('dev-')) {
+    return version;
+  }
+
   const match = version.match(/(?<versions>(?:[\d]+\.?){1,4})(?<suffix>-[^+]+)?(?<legacy>\+.+)?/)
   if (match) {
     return `${match.groups.versions}-a${buildSuffix}${match.groups.legacy ? match.groups.legacy : ''}`
@@ -100,6 +105,11 @@ function transformVersionsToNightlyBuildVersion(baseVersion, buildSuffix) {
 }
 
 function calcNightlyBuildPackageBaseVersion(version) {
+  // Handle dev- branch versions (e.g., dev-develop, dev-master)
+  if (version.startsWith('dev-')) {
+    return version; // Return as-is, it's already a valid Composer branch version
+  }
+
   if (! version.match(/^v?(?:\d+\.){0,3}\d+(?:-[a-z]\w*|)$/i)) {
     throw Error(`Unable to determine branch release version for input version "${version}"`)
   }


### PR DESCRIPTION
When building nightly packages, branch names like "develop" or "master" were being used directly as version strings, causing Satis to fail with "Invalid version string" errors. This fix ensures all branch names are converted to Composer's dev-branch format (e.g., "develop" → "dev-develop").

Changes:
  - package-modules.js: Update chooseNameAndVersion() to convert branch names from composer.json files or git refs to dev-branch format
  - package-modules.js: Update createComposerJsonOnlyPackage() to convert branch refs to dev-branch format for package filenames
  - release-branch-build-tools.js: Remove early conversion of branch refs that was causing issues with version determination

It's hard to test this fix, but I've been able to run `act schedule --container-architecture linux/amd64 -W .github/workflows/build-mageos-nightly.yml` and make it finish with no problem (except not being able to push the mirror because of missing secrets on my local build)

Fixes https://github.com/mage-os/generate-mirror-repo-js/issues/171