### PR TITLE
Bundle mage-os/module-pagebuilder-template-import-export

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -3,8 +3,8 @@
     "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
-    "mage-os/module-pagebuilder-template-import-export": "git@github.com:mage-os-lab/module-pagebuilder-template-import-export.git",
-    "mage-os/module-page-builder-widget": "git@github.com:mage-os-lab/module-page-builder-widget.git",
+    "mage-os/module-pagebuilder-template-import-export": "https://github.com/mage-os-lab/module-pagebuilder-template-import-export.git",
+    "mage-os/module-page-builder-widget": "https://github.com/mage-os-lab/module-page-builder-widget.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/theme-adminhtml-m137": "https://github.com/mage-os-lab/theme-adminhtml-m137.git"
   }

--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -2,9 +2,8 @@
   "dependencies": {
     "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
-    "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
     "mage-os/module-pagebuilder-template-import-export": "https://github.com/mage-os-lab/module-pagebuilder-template-import-export.git",
-    "mage-os/module-page-builder-widget": "https://github.com/mage-os-lab/module-page-builder-widget.git",
+    "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/theme-adminhtml-m137": "https://github.com/mage-os-lab/theme-adminhtml-m137.git"
   }

--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -3,6 +3,8 @@
     "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
+    "mage-os/module-pagebuilder-template-import-export": "git@github.com:mage-os-lab/module-pagebuilder-template-import-export.git",
+    "mage-os/module-page-builder-widget": "git@github.com:mage-os-lab/module-page-builder-widget.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/theme-adminhtml-m137": "https://github.com/mage-os-lab/theme-adminhtml-m137.git"
   }


### PR DESCRIPTION
I propose adding `mage-os-lab/module-pagebuilder-template-import-export` as a bundled module. [https://github.com/mage-os-lab/module-pagebuilder-template-import-export](https://github.com/mage-os-lab/module-pagebuilder-template-import-export)

- It provides import/export functionality for PageBuilder templates across instances.  
- It supports both local `.zip` template transfer and synchronization with Dropbox repositories.  
- It is maintained and has practical utility for agencies and merchants working with distributed content.  

# Implications
- Merchants and agencies can standardize PageBuilder content across multiple stores without manually recreating it.  
- Admins will be able to pull and sync reusable templates from Dropbox repositories (with multi-repository support).  
- Shops leveraging PageBuilder for rapid content development can speed up their workflows and reduce errors.  

# Risks
- Dependency on Dropbox for remote sync, requiring proper API configuration.  
- Admins may incorrectly configure Dropbox apps, leading to sync errors until setup is corrected.  

# Benefits
- Simplifies migration and reuse of PageBuilder templates across environments and projects.  
- Enables remote content repository workflows via Dropbox.  
- Reduces time-to-market for merchants using PageBuilder at scale.  

# PR
This PR results in the module being added as a pinned require of `mage-os/product-community-edition` like:

```
"mage-os/module-pagebuilder-template-import-export": "1.0.0",
```

Composer will then require it via Packagist. The latest published version will be pinned at the time of each release.  