### PR TITLE
Remove old Elasticsearch 8 workaround (fixes #38)

### DIFF
--- a/src/build-config/upstream-nightly-build-config.js
+++ b/src/build-config/upstream-nightly-build-config.js
@@ -5,19 +5,7 @@ const {mergeBuildConfigs} = require('../utils');
 const branchBuildConfig = {
   'magento2': {
     repoUrl: 'https://github.com/mage-os/mirror-magento2.git',
-    ref: '2.4-develop',
-    transform: {
-      // For magento/elasticsearch-8, remove the elasticsearch/elasticsearch dependency.
-      // See https://github.com/magento/magento2/issues/36687
-      'magento/module-elasticsearch-8': [
-        composerJson => {
-          if (composerJson?.require['elasticsearch/elasticsearch']) {
-            delete composerJson.require['elasticsearch/elasticsearch'];
-          }
-          return composerJson;
-        }
-      ]
-    }
+    ref: '2.4-develop'
   },
   'security-package': {
     repoUrl: 'https://github.com/mage-os/mirror-security-package.git',


### PR DESCRIPTION
We added this fix for ES7 vs ES8 dependencies in the nightlies, but it should no longer be necessary since 2.4.8 was released.

cf. #38 