### PR TITLE
Bundle aligent/magento2-pci-4-compatibility

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "aligent/magento2-pci-4-compatibility": "https://github.com/aligent/magento2-pci-4-compatibility.git",
     "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",


### PR DESCRIPTION
I propose adding Aligent_Pci4Compatibility as a bundled module. https://github.com/aligent/magento2-pci-4-compatibility

- It enforces policies required for PCI compliance
- It is slim, unintrusive, well integrated, and works; have used it on many production sites
- It is maintained, with negligible open issues

# Implications
- Admins with passwords that don't meet the new requirements will have to change them after login.
- Admin accounts will auto disable after 90 days.
- Admin session lifetime is reduced dramatically for most sites, to 15 minutes.

# Risks
- User frustration (but the frustration is with PCI 4 requirements, which are mandatory for most credit card processing).

# Benefits
- PCI 4 compatibility for session and password settings

# PR
This PR results in the module being added as a pinned require of mage-os/product-community-edition like:

    "aligent/magento2-pci-4-compatibility": "1.2.0",
which composer will then require via packagist, like any other third party package (Monolog, Laminas, Symphony, ...). The latest published version will be pinned at the time of each release.