### PR TITLE
Bundle mage-os/module-catalog-data-ai

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
+    "mage-os/module-catalog-data-ai": "https://github.com/mage-os-lab/module-catalog-data-ai.git",
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/theme-adminhtml-m137": "https://github.com/mage-os-lab/theme-adminhtml-m137.git"


### PR DESCRIPTION
I propose adding mage-os/module-catalog-data-ai as a bundled module. [https://github.com/mage-os-lab/module-catalog-data-ai](https://github.com/mage-os-lab/module-catalog-data-ai)

- It enables AI-powered product description and meta keyword generation, enhancing catalog quality and SEO.
- It is lightweight, easy to configure, and can be customized for specific catalog needs.

# Implications
- Disabled by default.
- OpenAI API key is required to enable AI-driven enrichment features.
- Product data (such as descriptions and keywords) will be auto-generated or improved when new products are created or edited.
- Prompts and AI models can be customized in the configuration for better results tailored to business needs.
- Admins should review generated content to ensure compliance with brand and legal standards.

# Risks
- Reliance on a third-party AI service (OpenAI); requires an active API key and connectivity.
- Generated content isn't guaranteed to be accurate.
- May cause big unexpected costs based on catalog size, configuration, and OpenAI API usage.

# Benefits
- Consistent and high-quality product content generated efficiently.
- Improved SEO and customer experience via automatically optimized descriptions and meta keywords.
- Reduces manual data entry burden for teams and enables rapid product catalog scaling.

# PR
This PR results in the module being added as a pinned require of mage-os/product-community-edition like:

    "mage-os/module-catalog-data-ai": "1.0.0",

which composer will then require via Packagist, like any other third party package. The latest published version will be pinned at the time of each release.
