### PR TITLE
Bundle mage-os/module-inventory-reservations-grid

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
+    "mage-os/module-inventory-reservations-grid": "https://github.com/mage-os-lab/module-inventory-reservations-grid.git",
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/theme-adminhtml-m137": "https://github.com/mage-os-lab/theme-adminhtml-m137.git"


### PR DESCRIPTION
I propose adding mage-os/module-inventory-reservations-grid as a bundled module. https://github.com/mage-os-lab/module-inventory-reservations-grid

- It provides a clear admin grid for Magento inventory reservations, improving visibility into reservation data.
- It is slim, purpose-built, and compatible with the latest Magento versions.
- It is maintained and focused on a single, important feature for inventory transparency.

# Implications
- Admins gain direct access to view and manage inventory reservations via a dedicated grid in the admin panel.
- May reveal underlying issues with reservations or stock management that require process adjustments.
- No impact on frontend performance or customer experience, as all changes are on the backend.

# Risks
- Potential for minor admin confusion if reservation data is unfamiliar, but documentation is available.
- Risk of unsafe inventory data operations, if admin enables the delete mass action and uses it unwisely. There are warnings against this.

# Benefits
- Enhanced transparency for inventory reservations, aiding troubleshooting and operational oversight.

# PR
This PR results in the module being added as a pinned require of mage-os/product-community-edition like:

    "mage-os/module-inventory-reservations-grid": "1.0.0",

which composer will then require via Packagist, like any other third party package. The latest published version will be pinned at the time of each release.