### PR TITLE
Bundle mage-os/module-theme-optimization

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
+    "mage-os/module-theme-optimization": "https://github.com/mage-os-lab/module-theme-optimization.git",
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/theme-adminhtml-m137": "https://github.com/mage-os-lab/theme-adminhtml-m137.git"


### PR DESCRIPTION
I propose adding mage-os/module-theme-optimization as a bundled module. [https://github.com/mage-os-lab/module-theme-optimization](https://github.com/mage-os-lab/module-theme-optimization)

- It improves Magento theme performance by enabling safe modern browser optimization features:
  - speculative loading
  - view transitions
  - bfcache
- It is lightweight and designed to seamlessly integrate without disrupting existing themes.
- It is actively maintained with a focus on enhancing user experience through faster page loads.

# Implications
- Page loads and transitions will be optimized, potentially reducing load times and improving site speed.
- Theme customization workflows remain unaffected.
- All features covered by feature flags, enabled by default.
- Some other solutions (Hyva) already implement some of the features, but Magento itself does not. Having both enabled at once would not have side effects except unnecessary code duplication. Power users can disable one or the other via settings to avoid that.

# Risks
- bfcache feature won't work with non-native FPC solutions; others (Varnish, Fastly, ...) require their own support

# Benefits
- Faster perceived frontend performance leading to better customer engagement and SEO.
- Reduced page load times improving overall user satisfaction.
- Simple integration with minimal configuration needed.

# PR
This PR results in the module being added as a pinned require of mage-os/product-community-edition like:

    "mage-os/module-theme-optimization": "1.0.0",

which composer will then require via Packagist, like any other third party package. The latest published version will be pinned at the time of each release.