### PR TITLE
Bundle mage-os/module-page-builder-widget

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
+    "mage-os/module-page-builder-widget": "https://github.com/mage-os-lab/module-page-builder-widget.git",
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/theme-adminhtml-m137": "https://github.com/mage-os-lab/theme-adminhtml-m137.git"


### PR DESCRIPTION
I propose adding mage-os/module-page-builder-widget as a bundled module. https://github.com/mage-os-lab/module-page-builder-widget

- Allows you to add widgets directly to Page Builder content, natively, with preview

# Implications
- No impact on frontend performance beyond standard Page Builder and widget rendering
- No impact on existing Page Builder content

# Risks
- Potential minor compatibility issues with heavily customized Page Builder setups

# Benefits
- Expanded creative control for merchants building pages and content
- Improved Page Builder capabilities and experience

# PR
This PR results in the module being added as a pinned require of mage-os/product-community-edition like:

    "mageos/module-page-builder-widget": "1.0.0",

which composer will then require via Packagist, like any other third party package. The latest published version will be pinned at the time of each release.