### PR TITLE
Bundle mage-os/module-meta-robots-tag

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
+    "mage-os/meta-robots-tag": "https://github.com/mage-os/module-meta-robots-tag.git",
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/theme-adminhtml-m137": "https://github.com/mage-os-lab/theme-adminhtml-m137.git"

--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
-    "mage-os/meta-robots-tag": "https://github.com/mage-os/module-meta-robots-tag.git",
+    "mage-os/module-meta-robots-tag": "https://github.com/mage-os/module-meta-robots-tag.git",
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/theme-adminhtml-m137": "https://github.com/mage-os-lab/theme-adminhtml-m137.git"


### PR DESCRIPTION
I propose adding mage-os/module-meta-robots-tag as a bundled module. https://github.com/mage-os/module-meta-robots-tag

# Implications
- Admins can set meta robots tags directly in the admin, on a per-entity basis, to manage crawl and indexing behavior.
- Enhanced SEO control without changes to theme or frontend performance.
- No workflow disruption; settings are updated through standard edit pages on the Magento admin UI.

# Risks
- Improper use could impact SEO, so care is needed during use. But this isn't new, since robot tags can already be managed globally.
- Minimal risk overall since the module only adjusts meta tags.

# Benefits
- Improved SEO and control over search indexation for catalog and content pages.
- Quick, flexible adjustments to search engine directives as needed.

# PR
This PR results in the module being added as a pinned require of mage-os/product-community-edition like:

    "mageos/module-meta-robots-tag": "1.0.0",

which composer will then require via Packagist, like any other third party package. The latest published version will be pinned at the time of each release.