### PR TITLE
Fix magento2-base build error for new releases

### DIFF
--- a/src/package-modules.js
+++ b/src/package-modules.js
@@ -229,6 +229,8 @@ async function createPackageForRef(instruction, package, release) {
   if (!excludes.includes('composer.json')) excludes.push('composer.json');
   if (!excludes.includes('.git/')) excludes.push('.git/');
 
+  package.composerJsonFile ??= package.composerJsonPath;
+
   let magentoName = lastTwoDirs(package.dir) || '';
   const composerJson = await getComposerJson(instruction, package, release.ref);
 

--- a/src/release-build-tools.js
+++ b/src/release-build-tools.js
@@ -224,6 +224,9 @@ function updateComposerConfigFromMagentoToMageOs(instruction, release, composerC
 async function prepPackageForRelease(instruction, package, release, workingCopyPath) {
   console.log(`Preparing ${package.label}`);
 
+  // Reset value in case it was set during history mirroring
+  package.composerJsonFile = null;
+
   const composerConfig = JSON.parse(await readComposerJson(instruction.repoUrl, package.dir, release.ref));
   updateComposerConfigFromMagentoToMageOs(instruction, release, composerConfig);
 


### PR DESCRIPTION
`magento2-base-2.0.0-beta1.zip` didn't build during a preview release. This fixes that.

Issue was caused by changes from composerJsonPath -> composerJsonFile for mirroring during the refactoring

Two code bugs involved and fixed:
- package.composerJsonFile would survive from history building to new release build (only if run without --skipHistory), causing it to rebuild a previous version for the new release
- package.composerJsonFile would not be set to the value of composerJsonPath for new releases, causing it to not apply the template (came out `magento2ce` instead, the package name of the root ./composer.json in Magento core)