### PR TITLE
  Fix authentication for download-missing-packages workflow

### DIFF
--- a/.github/workflows/download-missing-packages.yml
+++ b/.github/workflows/download-missing-packages.yml
@@ -35,13 +35,16 @@ jobs:
           git config user.name "GitHub Actions Bot"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Configure Composer Authentication
+        run: |
+          mkdir -p ~/.composer
+          echo '${{ secrets.COMPOSER_AUTH }}' > ~/.composer/auth.json
+
       - name: Run mirror script
         run: node src/make/mirror.js --outputDir=build
 
       - name: Run download script
         run: php bin/download-all-missing-packages-from-repo-magento-com.php
-        env:
-          COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
       - name: Check for changes
         id: git-check


### PR DESCRIPTION
 Fixes #219

  ## Problem
  The download-missing-packages workflow was failing because neither `composer create-project` nor the PHP download script could authenticate with repo.magento.com. The workflow was setting `COMPOSER_AUTH` as an environment variable, but the PHP script only checks for `auth.json` files.

  ## Solution
  Added a step to create `~/.composer/auth.json` from the `COMPOSER_AUTH` secret before running the scripts. This ensures:
  - `composer create-project` can authenticate when creating Magento projects
  - The PHP download script can find credentials at `~/.composer/auth.json`