### PR TITLE
[FEAT] Set release stability based on the release version

### DIFF
--- a/src/package-modules.js
+++ b/src/package-modules.js
@@ -101,6 +101,30 @@ async function getComposerJson(instruction, package, ref) {
 }
 
 /**
+ * Determine the stability level of a composer version string
+ * @param {string} version - The version string to check (e.g. "2.4.0-beta1", "1.0.0", "dev-master")
+ * @returns {string} - Returns 'dev', 'alpha', 'beta', 'RC', 'stable', or 'patch'
+ */
+function getVersionStability(version) {
+  version = version.toLowerCase();
+  
+  if (version.startsWith('dev-') || version.includes('-dev')) {
+    return 'dev';
+  }
+  if (version.includes('-alpha')) {
+    return 'alpha';
+  }
+  if (version.includes('-beta')) {
+    return 'beta';
+  }
+  if (version.includes('-rc')) {
+    return 'RC';
+  }
+
+  return 'stable';
+}
+
+/**
  * @param {repositoryBuildDefinition} instruction 
  * @param {packageDefinition} package 
  * @param {*} magentoName 
@@ -545,18 +569,18 @@ async function determineMagentoCommunityEditionProject(url, ref, release) {
  *
  * @param {repositoryBuildDefinition} instruction
  * @param {buildState} release
- * @param {{minimumStability:String|undefined, description:String|undefined}} options
+ * @param {{description:String|undefined, transform: Array<String, Function>}} options
  * @returns {Promise<{}>}
  */
 async function createMagentoCommunityEditionProject(instruction, release, options) {
   const defaults = {
-    minimumStability: 'stable',
     description: 'eCommerce Platform for Growth (Community Edition)',
     transform: {},
   };
-  const {minimumStability, description, transform} = Object.assign(defaults, (options || {}))
+  const {description, transform} = Object.assign(defaults, (options || {}))
   const name = `${instruction.vendor}/project-community-edition`;
   const version = release.version || release.dependencyVersions[name] || release.ref;
+  const minimumStability = getVersionStability(version);
   const {packageFilepath, files} = await createComposerJsonOnlyPackage(
     instruction,
     release,

--- a/src/release-branch-build-tools.js
+++ b/src/release-branch-build-tools.js
@@ -156,10 +156,7 @@ async function processBuildInstruction(instruction, release) {
     console.log('Packaging Magento Community Edition Project');
     built = await createMagentoCommunityEditionProject(
       instruction,
-      release,
-      {
-        minimumStability: 'alpha'
-      }
+      release
     );
     Object.assign(packages, built);
   }

--- a/src/release-build-tools.js
+++ b/src/release-build-tools.js
@@ -273,8 +273,7 @@ async function buildMageOsProjectCommunityEditionMetapackage(instruction, releas
     instruction,
     release,
     {
-      minimumStability: 'stable',
-      description: 'Community built eCommerce Platform for Growth',
+      description: 'Community-built eCommerce Platform for Growth',
       transform: {
         [`${instruction.vendor}/project-community-edition`]: [
           (composerConfig) => {


### PR DESCRIPTION
This changes release generation to set the minimum stability of `project-community-edition` based on the release version, instead of a predefined value.

The value will default to `stable` (like now), unless the version includes `dev`, `alpha`, `beta`, `rc`, in which case it'll be set to that instead.

This means that we can publish preview releases such as, hypothetically, `2.0.0-beta2`, and have them installable with `composer create-project ...` without hitting a stability error due to non-stable dependencies.