### PR TITLE
chore: change Mage-OS release branches from release/1.x to main

### DIFF
--- a/src/build-config/mageos-release-build-config.js
+++ b/src/build-config/mageos-release-build-config.js
@@ -5,7 +5,7 @@ const {mergeBuildConfigs} = require('../utils');
 const releaseBuildConfig = {
   'magento2': {
     repoUrl: 'https://github.com/mage-os/mageos-magento2.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
     packageIndividual: [
       {
@@ -16,112 +16,112 @@ const releaseBuildConfig = {
   },
   'security-package': {
     repoUrl: 'https://github.com/mage-os/mageos-security-package.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   'inventory': {
     repoUrl: 'https://github.com/mage-os/mageos-inventory.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   'inventory-composer-installer': {
     repoUrl: 'https://github.com/mage-os/mageos-inventory-composer-installer.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   'page-builder': {
     repoUrl: 'https://github.com/mage-os/mageos-magento2-page-builder.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   'adobe-stock-integration': {
     repoUrl: 'https://github.com/mage-os/mageos-adobe-stock-integration.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   'magento-allure-phpunit': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-allure-phpunit.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.1.0',
   },
   'magento-composer-installer': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-composer-installer.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   'composer': {
     repoUrl: 'https://github.com/mage-os/mageos-composer.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   'composer-root-update-plugin': {
     repoUrl: 'https://github.com/mage-os/mageos-composer-root-update-plugin.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   'composer-dependency-version-audit-plugin': {
     repoUrl: 'https://github.com/mage-os/mageos-composer-dependency-version-audit-plugin.git',
-    ref: 'release/1.x',
+    ref: 'mage-os',
     fromTag: '1.0.0',
   },
   'magento2-sample-data': {
     repoUrl: 'https://github.com/mage-os/mageos-magento2-sample-data.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   'magento-coding-standard': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-coding-standard.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   'magento2-functional-testing-framework': {
     repoUrl: 'https://github.com/mage-os/mageos-magento2-functional-testing-framework.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   'magento-zend-db': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-zend-db.git',
-    ref: 'release/1.x',
+    ref: 'mage-os',
     fromTag: '1.0.0',
   },
   'magento-zend-loader': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-zend-loader.git',
-    ref: 'release/1.x',
+    ref: 'mage-os',
     fromTag: '1.0.0',
   },
   'magento-zend-pdf': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-zend-pdf.git',
-    ref: 'release/1.x',
+    ref: 'mage-os',
     fromTag: '1.0.0',
   },
   'magento-zend-cache': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-zend-cache.git',
-    ref: 'release/1.x',
+    ref: 'mage-os',
     fromTag: '1.0.0',
   },
   'magento-zend-exception': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-zend-exception.git',
-    ref: 'release/1.x',
+    ref: 'mage-os',
     fromTag: '1.0.0',
   },
   'magento-zend-log': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-zend-log.git',
-    ref: 'release/1.x',
+    ref: 'mage-os',
     fromTag: '1.0.0',
   },
   'magento-zend-memory': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-zend-memory.git',
-    ref: 'release/1.x',
+    ref: 'mage-os',
     fromTag: '1.0.0',
   },
   'magento-zf-db': {
     repoUrl: 'https://github.com/mage-os/mageos-magento-zf-db.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.1.0',
   },
   'php-compatibility-fork': {
     repoUrl: 'https://github.com/mage-os/mageos-PHPCompatibilityFork.git',
-    ref: 'release/1.x',
+    ref: 'main',
     fromTag: '1.0.0',
   },
   // 'theme-adminhtml-m137': {


### PR DESCRIPTION
In conjunction with https://github.com/mage-os/mageos-magento2/issues/165 and https://github.com/mage-os/terraform/pull/117

Changes the release source branches for Mage-OS Distribution from `release/1.x` to `main` (or `mage-os` in case of conflict)

Will be necessary for us to merge this before we can build any more Mage-OS previews or releases.