### PR TITLE
Fix failing integration tests due to composer 1 EOL

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -19,7 +19,7 @@ jobs:
         - uses: actions/checkout@v3
         - uses: mage-os/github-actions/supported-version@main
           with:
-            kind: all
+            kind: usable
           id: supported-version
 
   integrity-check:


### PR DESCRIPTION
Related to https://github.com/mage-os/github-actions/pull/299: Set the matrix calculator kind to `usable` instead of `all`, to skip versions that are no longer usable (in this case, due to Packagist ending support for composer 1).

Must wait until that PR is merged to process this one. Marking this draft for now.