### PR TITLE
Replace should not be merged with require section

### DIFF
--- a/src/package-modules.js
+++ b/src/package-modules.js
@@ -523,7 +523,6 @@ async function createMagentoCommunityEditionMetapackage(instruction, release, op
         require: Object.assign(
           {},
           refComposerConfig.require,
-          refComposerConfig.replace,
           additionalDependencies,
           {[`${instruction.vendor}/magento2-base`]: version}
         ),


### PR DESCRIPTION
Because of the hardening in latest version of `composer` (a good thing) invalid packages cannot be installed anymore.

## The problem

This morning I tried to setup a clean Magento based on the mage-os mirror (my default) and it failed.

```
  Problem 1
    - Root composer.json requires magento/product-community-edition 2.4.8-p3 -> satisfiable by magento/product-community-edition[2.4.8-p3].
    - magento/product-community-edition 2.4.8-p3 requires components/jquery 1.11.0 -> found components/jquery[1.11.0] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("PKSA-jvpv-pcrn-dfzc", "PKSA-jqsz-ykjr-qncb") to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
```

My question, why does Magento require `components/jquery:1.11.0` ?

I opened the original [composer.json](https://github.com/mage-os/mirror-magento2/blob/2.4-develop/composer.json) to see why it was required. It wasn't, hmm, that's weird.

## Research and solution

So, next, try to install from repo.magento.com to see if I can reproduce the bug with upstream, and it installed without any hassle.

Which lead in the research of the generator, because why did we do we have a different version from the original.

Locally disabled and build the project and after that I could install Magento like before.
It now is 100% the same with repo.magento.com again (except the source of coarse) :raised_hands: 

## Affected version

- all current builds as stated in the readme.md

