### PR TITLE
Fix cleanup of project directory upon composer failure

### DIFF
--- a/bin/download-all-missing-packages-from-repo-magento-com.php
+++ b/bin/download-all-missing-packages-from-repo-magento-com.php
@@ -44,6 +44,11 @@ foreach ($versions as $version) {
 foreach ($latestVersions as $version) {
     echo "Processing version: $version\n";
 
+    // Remove project directory
+    echo "Cleaning up project directory...\n";
+    $command = "rm -rf project-community-edition";
+    passthru($command);
+
     // Create project directory using composer
     echo "Creating Magento project with version $version...\n";
     $command = "composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition:$version --ignore-platform-reqs --no-progress -q -n --no-plugins";
@@ -59,12 +64,12 @@ foreach ($latestVersions as $version) {
     $command = "php bin/download-missing-packages-from-repo-magento-com.php project-community-edition/composer.lock build resource/additional-packages";
     passthru($command, $returnCode);
 
-    // Remove project directory
-    echo "Cleaning up project directory...\n";
-    $command = "rm -rf project-community-edition";
-    passthru($command);
-
     echo "\n\n";
 }
+
+// Remove project directory
+echo "Cleaning up project directory...\n";
+$command = "rm -rf project-community-edition";
+passthru($command);
 
 echo "Done!\n";


### PR DESCRIPTION
This should fix the packages download script error at https://github.com/mage-os/generate-mirror-repo-js/actions/runs/20588610384/job/59129702725 -- the issue is that 2.3.7-p1 isn't installable because of the composer 1 EOL, but that creates the `project-community-edition` folder and never cleans it up, and all composer commands thereafter fail because the folder and composer.json already exist from that failed instance. Doing the FS cleanup before composer command should fix it.