### PR TITLE
Fix missing magento_version in 2.0.0

### DIFF
--- a/resource/history/mage-os/product-community-edition/2.0.0.json
+++ b/resource/history/mage-os/product-community-edition/2.0.0.json
@@ -12,5 +12,8 @@
     "mage-os/page-builder": "2.0.0",
     "mage-os/security-package": "2.0.0",
     "mage-os/theme-adminhtml-m137": "1.3.2"
+  },
+  "extra": {
+    "magento_version": "2.4.8-p3"
   }
 }


### PR DESCRIPTION
This should fix https://github.com/mage-os/mageos-magento2/issues/192