### PR TITLE
chore: added release history files for Mage-OS 2.1.0

### DIFF
--- a/resource/history/mage-os/magento2-base/2.1.0.json
+++ b/resource/history/mage-os/magento2-base/2.1.0.json
@@ -1,0 +1,566 @@
+{
+  "name": "mage-os/magento2-base",
+  "description": "Magento 2 Base (Community Edition)",
+  "type": "magento2-component",
+  "license": [
+    "OSL-3.0",
+    "AFL-3.0"
+  ],
+  "version": "2.1.0",
+  "require": {
+    "colinmollenhour/credis": "^1.15",
+    "colinmollenhour/php-redis-session-abstract": "^2.0",
+    "composer/composer": "^2.0, !=2.2.16",
+    "composer/semver": "^3.4.3",
+    "laminas/laminas-code": "^4.13",
+    "laminas/laminas-eventmanager": "^3.11",
+    "laminas/laminas-http": "^2.15",
+    "laminas/laminas-modulemanager": "^2.11",
+    "laminas/laminas-mvc": "^3.6",
+    "laminas/laminas-servicemanager": "^3.16",
+    "laminas/laminas-soap": "^2.10",
+    "laminas/laminas-stdlib": "^3.11",
+    "laminas/laminas-uri": "^2.9",
+    "laminas/laminas-validator": "^2.23",
+    "mage-os/composer": "2.1.0",
+    "mage-os/zend-cache": "2.1.0",
+    "mage-os/zend-db": "2.1.0",
+    "monolog/monolog": "^3.6",
+    "pelago/emogrifier": "^7.0",
+    "php-amqplib/php-amqplib": "^3.2",
+    "psr/log": "^2 || ^3",
+    "symfony/console": "^6.4",
+    "symfony/filesystem": "^7.2.0",
+    "symfony/finder": "^6.4",
+    "symfony/http-foundation": "^7.2.3",
+    "symfony/mailer": "^6.4",
+    "symfony/mime": "^6.4",
+    "symfony/polyfill-php80": "^1.31.0",
+    "symfony/process": "^6.4",
+    "webonyx/graphql-php": "^15.0"
+  },
+  "conflict": {
+    "gene/bluefoot": "*"
+  },
+  "replace": {
+    "trentrichardson/jquery-timepicker-addon": "1.4.3",
+    "components/jquery": "1.11.0",
+    "components/jqueryui": "1.10.4",
+    "twbs/bootstrap": "3.1.0"
+  },
+  "extra": {
+    "chmod": [
+      {
+        "mask": "0755",
+        "path": "bin/magento"
+      }
+    ],
+    "component_paths": {
+      "components/jquery": [
+        "lib/web/jquery.js",
+        "lib/web/jquery/jquery.min.js"
+      ],
+      "components/jqueryui": "lib/web/jquery/jquery-ui.js",
+      "trentrichardson/jquery-timepicker-addon": "lib/web/jquery/jquery-ui-timepicker-addon.js",
+      "twbs/bootstrap": "lib/web/jquery/jquery.tabs.js"
+    },
+    "map": [
+      [
+        ".editorconfig",
+        ".editorconfig"
+      ],
+      [
+        ".htaccess",
+        ".htaccess"
+      ],
+      [
+        ".htaccess.sample",
+        ".htaccess.sample"
+      ],
+      [
+        ".php-cs-fixer.dist.php",
+        ".php-cs-fixer.dist.php"
+      ],
+      [
+        ".user.ini",
+        ".user.ini"
+      ],
+      [
+        "CHANGELOG.md",
+        "CHANGELOG.md"
+      ],
+      [
+        "COPYING.txt",
+        "COPYING.txt"
+      ],
+      [
+        "Gruntfile.js.sample",
+        "Gruntfile.js.sample"
+      ],
+      [
+        "LICENSE.txt",
+        "LICENSE.txt"
+      ],
+      [
+        "LICENSE_AFL.txt",
+        "LICENSE_AFL.txt"
+      ],
+      [
+        "SECURITY.md",
+        "SECURITY.md"
+      ],
+      [
+        "app/.htaccess",
+        "app/.htaccess"
+      ],
+      [
+        "app/autoload.php",
+        "app/autoload.php"
+      ],
+      [
+        "app/bootstrap.php",
+        "app/bootstrap.php"
+      ],
+      [
+        "app/design/adminhtml/Magento",
+        "app/design/adminhtml/Magento"
+      ],
+      [
+        "app/design/frontend/Magento",
+        "app/design/frontend/Magento"
+      ],
+      [
+        "app/etc/NonComposerComponentRegistration.php",
+        "app/etc/NonComposerComponentRegistration.php"
+      ],
+      [
+        "app/etc/db_schema.xml",
+        "app/etc/db_schema.xml"
+      ],
+      [
+        "app/etc/di.xml",
+        "app/etc/di.xml"
+      ],
+      [
+        "app/etc/registration_globlist.php",
+        "app/etc/registration_globlist.php"
+      ],
+      [
+        "auth.json.sample",
+        "auth.json.sample"
+      ],
+      [
+        "bin/.htaccess",
+        "bin/.htaccess"
+      ],
+      [
+        "bin/magento",
+        "bin/magento"
+      ],
+      [
+        "dev/.htaccess",
+        "dev/.htaccess"
+      ],
+      [
+        "dev/tests/.gitignore",
+        "dev/tests/.gitignore"
+      ],
+      [
+        "dev/tests/acceptance",
+        "dev/tests/acceptance"
+      ],
+      [
+        "dev/tests/api-functional/.gitignore",
+        "dev/tests/api-functional/.gitignore"
+      ],
+      [
+        "dev/tests/api-functional/_files",
+        "dev/tests/api-functional/_files"
+      ],
+      [
+        "dev/tests/api-functional/allure",
+        "dev/tests/api-functional/allure"
+      ],
+      [
+        "dev/tests/api-functional/config",
+        "dev/tests/api-functional/config"
+      ],
+      [
+        "dev/tests/api-functional/framework",
+        "dev/tests/api-functional/framework"
+      ],
+      [
+        "dev/tests/api-functional/isolate_gql.txt",
+        "dev/tests/api-functional/isolate_gql.txt"
+      ],
+      [
+        "dev/tests/api-functional/isolate_rest.txt",
+        "dev/tests/api-functional/isolate_rest.txt"
+      ],
+      [
+        "dev/tests/api-functional/phpunit_graphql.xml.dist",
+        "dev/tests/api-functional/phpunit_graphql.xml.dist"
+      ],
+      [
+        "dev/tests/api-functional/phpunit_rest.xml.dist",
+        "dev/tests/api-functional/phpunit_rest.xml.dist"
+      ],
+      [
+        "dev/tests/api-functional/phpunit_soap.xml.dist",
+        "dev/tests/api-functional/phpunit_soap.xml.dist"
+      ],
+      [
+        "dev/tests/api-functional/testsuite/Magento",
+        "dev/tests/api-functional/testsuite/Magento"
+      ],
+      [
+        "dev/tests/config",
+        "dev/tests/config"
+      ],
+      [
+        "dev/tests/error_handler.php",
+        "dev/tests/error_handler.php"
+      ],
+      [
+        "dev/tests/integration/.gitignore",
+        "dev/tests/integration/.gitignore"
+      ],
+      [
+        "dev/tests/integration/_files",
+        "dev/tests/integration/_files"
+      ],
+      [
+        "dev/tests/integration/allure",
+        "dev/tests/integration/allure"
+      ],
+      [
+        "dev/tests/integration/bin",
+        "dev/tests/integration/bin"
+      ],
+      [
+        "dev/tests/integration/etc",
+        "dev/tests/integration/etc"
+      ],
+      [
+        "dev/tests/integration/framework",
+        "dev/tests/integration/framework"
+      ],
+      [
+        "dev/tests/integration/isolate.txt",
+        "dev/tests/integration/isolate.txt"
+      ],
+      [
+        "dev/tests/integration/phpunit.xml.dist",
+        "dev/tests/integration/phpunit.xml.dist"
+      ],
+      [
+        "dev/tests/integration/testsuite/Magento",
+        "dev/tests/integration/testsuite/Magento"
+      ],
+      [
+        "dev/tests/integration/tmp",
+        "dev/tests/integration/tmp"
+      ],
+      [
+        "dev/tests/js",
+        "dev/tests/js"
+      ],
+      [
+        "dev/tests/setup-integration",
+        "dev/tests/setup-integration"
+      ],
+      [
+        "dev/tests/static/.gitignore",
+        "dev/tests/static/.gitignore"
+      ],
+      [
+        "dev/tests/static/allure",
+        "dev/tests/static/allure"
+      ],
+      [
+        "dev/tests/static/framework",
+        "dev/tests/static/framework"
+      ],
+      [
+        "dev/tests/static/get_github_changes.php",
+        "dev/tests/static/get_github_changes.php"
+      ],
+      [
+        "dev/tests/static/phpunit-all.xml.dist",
+        "dev/tests/static/phpunit-all.xml.dist"
+      ],
+      [
+        "dev/tests/static/phpunit.xml.dist",
+        "dev/tests/static/phpunit.xml.dist"
+      ],
+      [
+        "dev/tests/static/testsuite/Magento",
+        "dev/tests/static/testsuite/Magento"
+      ],
+      [
+        "dev/tests/static/tmp",
+        "dev/tests/static/tmp"
+      ],
+      [
+        "dev/tests/unit/.gitignore",
+        "dev/tests/unit/.gitignore"
+      ],
+      [
+        "dev/tests/unit/allure",
+        "dev/tests/unit/allure"
+      ],
+      [
+        "dev/tests/unit/framework",
+        "dev/tests/unit/framework"
+      ],
+      [
+        "dev/tests/unit/phpunit.xml.dist",
+        "dev/tests/unit/phpunit.xml.dist"
+      ],
+      [
+        "dev/tests/unit/tmp",
+        "dev/tests/unit/tmp"
+      ],
+      [
+        "dev/tests/utils",
+        "dev/tests/utils"
+      ],
+      [
+        "dev/tests/varnish",
+        "dev/tests/varnish"
+      ],
+      [
+        "dev/tools",
+        "dev/tools"
+      ],
+      [
+        "generated",
+        "generated"
+      ],
+      [
+        "grunt-config.json.sample",
+        "grunt-config.json.sample"
+      ],
+      [
+        "lib/.htaccess",
+        "lib/.htaccess"
+      ],
+      [
+        "lib/internal/GnuFreeFont",
+        "lib/internal/GnuFreeFont"
+      ],
+      [
+        "lib/internal/LinLibertineFont",
+        "lib/internal/LinLibertineFont"
+      ],
+      [
+        "lib/web/blank.html",
+        "lib/web/blank.html"
+      ],
+      [
+        "lib/web/chartjs",
+        "lib/web/chartjs"
+      ],
+      [
+        "lib/web/css",
+        "lib/web/css"
+      ],
+      [
+        "lib/web/fonts",
+        "lib/web/fonts"
+      ],
+      [
+        "lib/web/fotorama",
+        "lib/web/fotorama"
+      ],
+      [
+        "lib/web/hugerte",
+        "lib/web/hugerte"
+      ],
+      [
+        "lib/web/i18n",
+        "lib/web/i18n"
+      ],
+      [
+        "lib/web/images",
+        "lib/web/images"
+      ],
+      [
+        "lib/web/jquery",
+        "lib/web/jquery"
+      ],
+      [
+        "lib/web/jquery.js",
+        "lib/web/jquery.js"
+      ],
+      [
+        "lib/web/js-cookie",
+        "lib/web/js-cookie"
+      ],
+      [
+        "lib/web/js-storage",
+        "lib/web/js-storage"
+      ],
+      [
+        "lib/web/knockoutjs",
+        "lib/web/knockoutjs"
+      ],
+      [
+        "lib/web/legacy-build.min.js",
+        "lib/web/legacy-build.min.js"
+      ],
+      [
+        "lib/web/less",
+        "lib/web/less"
+      ],
+      [
+        "lib/web/lib",
+        "lib/web/lib"
+      ],
+      [
+        "lib/web/mage",
+        "lib/web/mage"
+      ],
+      [
+        "lib/web/magnifier",
+        "lib/web/magnifier"
+      ],
+      [
+        "lib/web/matchMedia.js",
+        "lib/web/matchMedia.js"
+      ],
+      [
+        "lib/web/moment-timezone-with-data.js",
+        "lib/web/moment-timezone-with-data.js"
+      ],
+      [
+        "lib/web/moment.js",
+        "lib/web/moment.js"
+      ],
+      [
+        "lib/web/prototype",
+        "lib/web/prototype"
+      ],
+      [
+        "lib/web/requirejs",
+        "lib/web/requirejs"
+      ],
+      [
+        "lib/web/scriptaculous",
+        "lib/web/scriptaculous"
+      ],
+      [
+        "lib/web/spacer.gif",
+        "lib/web/spacer.gif"
+      ],
+      [
+        "lib/web/underscore.js",
+        "lib/web/underscore.js"
+      ],
+      [
+        "lib/web/varien",
+        "lib/web/varien"
+      ],
+      [
+        "lib/web/vimeo",
+        "lib/web/vimeo"
+      ],
+      [
+        "nginx.conf.sample",
+        "nginx.conf.sample"
+      ],
+      [
+        "package.json.sample",
+        "package.json.sample"
+      ],
+      [
+        "phpserver",
+        "phpserver"
+      ],
+      [
+        "pub/.htaccess",
+        "pub/.htaccess"
+      ],
+      [
+        "pub/.user.ini",
+        "pub/.user.ini"
+      ],
+      [
+        "pub/cron.php",
+        "pub/cron.php"
+      ],
+      [
+        "pub/errors",
+        "pub/errors"
+      ],
+      [
+        "pub/get.php",
+        "pub/get.php"
+      ],
+      [
+        "pub/health_check.php",
+        "pub/health_check.php"
+      ],
+      [
+        "pub/index.php",
+        "pub/index.php"
+      ],
+      [
+        "pub/media/.htaccess",
+        "pub/media/.htaccess"
+      ],
+      [
+        "pub/media/custom_options",
+        "pub/media/custom_options"
+      ],
+      [
+        "pub/media/customer/.htaccess",
+        "pub/media/customer/.htaccess"
+      ],
+      [
+        "pub/media/customer_address",
+        "pub/media/customer_address"
+      ],
+      [
+        "pub/media/downloadable/.htaccess",
+        "pub/media/downloadable/.htaccess"
+      ],
+      [
+        "pub/media/import",
+        "pub/media/import"
+      ],
+      [
+        "pub/media/sitemap",
+        "pub/media/sitemap"
+      ],
+      [
+        "pub/media/theme_customization/.htaccess",
+        "pub/media/theme_customization/.htaccess"
+      ],
+      [
+        "pub/opt",
+        "pub/opt"
+      ],
+      [
+        "pub/static/.htaccess",
+        "pub/static/.htaccess"
+      ],
+      [
+        "pub/static.php",
+        "pub/static.php"
+      ],
+      [
+        "setup",
+        "setup"
+      ],
+      [
+        "var/.htaccess",
+        "var/.htaccess"
+      ],
+      [
+        "vendor/.htaccess",
+        "vendor/.htaccess"
+      ]
+    ]
+  }
+}

--- a/resource/history/mage-os/product-community-edition/2.1.0.json
+++ b/resource/history/mage-os/product-community-edition/2.1.0.json
@@ -1,0 +1,19 @@
+{
+  "require": {
+    "aligent/magento2-pci-4-compatibility": "1.3.1",
+    "creatuity/magento2-interceptors": "1.3.7",
+    "mage-os/inventory-metapackage": "2.1.0",
+    "mage-os/module-automatic-translation": "1.9.1",
+    "mage-os/module-inventory-reservations-grid": "1.0.2",
+    "mage-os/module-meta-robots-tag": "1.2.0",
+    "mage-os/module-page-builder-template-import-export": "1.6.2",
+    "mage-os/module-page-builder-widget": "1.3.3",
+    "mage-os/module-theme-optimization": "2.2.0",
+    "mage-os/page-builder": "2.1.0",
+    "mage-os/security-package": "2.1.0",
+    "mage-os/theme-adminhtml-m137": "1.3.2"
+  },
+  "extra": {
+    "magento_version": "2.4.8-p3"
+  }
+}

--- a/resource/history/mage-os/project-community-edition/2.1.0.json
+++ b/resource/history/mage-os/project-community-edition/2.1.0.json
@@ -1,0 +1,6 @@
+{
+  "require": {
+    "mage-os/composer-root-update-plugin": "2.1.0",
+    "mage-os/composer-dependency-version-audit-plugin": "2.1.0"
+  }
+}


### PR DESCRIPTION
Compare to https://github.com/mage-os/generate-mirror-repo-js/pull/270 for the previous release