### PR TITLE
fix: added refs to the builstate for nightly builds

### DIFF
--- a/src/make/mageos-nightly.js
+++ b/src/make/mageos-nightly.js
@@ -31,9 +31,5 @@ if (options.gitRepoDir) {
   repo.setStorageDir(options.gitRepoDir);
 }
 
-let releaseContext = new buildState({
-  composerRepoUrl: options.repoUrl || 'https://nightly.mage-os.org/',
-});
-
-processNightlyBuildInstructions(branchBuildInstructions, releaseContext);
+processNightlyBuildInstructions(branchBuildInstructions, options.repoUrl || 'https://nightly.mage-os.org/');
 

--- a/src/make/upstream-nightly.js
+++ b/src/make/upstream-nightly.js
@@ -1,6 +1,6 @@
 const repo = require('./../repository');
 const parseOptions = require('parse-options');
-const {setArchiveBaseDir, setMageosPackageRepoUrl} = require('./../package-modules');
+const {setArchiveBaseDir} = require('./../package-modules');
 const {processNightlyBuildInstructions} = require('./../release-branch-build-tools');
 const {buildConfig: branchBuildInstructions} = require('./../build-config/upstream-nightly-build-config');
 
@@ -31,9 +31,5 @@ if (options.gitRepoDir) {
   repo.setStorageDir(options.gitRepoDir);
 }
 
-if (options.repoUrl) {
-  setMageosPackageRepoUrl(options.repoUrl);
-}
-
-processNightlyBuildInstructions(branchBuildInstructions);
+processNightlyBuildInstructions(branchBuildInstructions, options.repoUrl || 'https://upstream-nightly.mage-os.org/');
 

--- a/src/release-branch-build-tools.js
+++ b/src/release-branch-build-tools.js
@@ -116,6 +116,7 @@ async function processBuildInstruction(instruction, release) {
   let packages = {};
   let built = {};
 
+  release.ref = instruction.ref;
   await repo.pull(instruction.repoUrl, instruction.ref);
 
   for (const package of (instruction.packageDirs || [])) {
@@ -150,9 +151,10 @@ async function processBuildInstruction(instruction, release) {
  * @param {Array<repositoryBuildDefinition>} instructions
  * @returns {Promise<void>}
  */
-async function processNightlyBuildInstructions(instructions) {
+async function processNightlyBuildInstructions(instructions, repoUrl) {
   const releaseSuffix = getReleaseDateString();
   let release = new buildState({
+    composerRepoUrl: repoUrl,
     fallbackVersion: transformVersionsToNightlyBuildVersion('0.0.1', releaseSuffix), // version to use for previously unreleased packages
     dependencyVersions: await getPackageVersionsForBuildInstructions(instructions, releaseSuffix),
   });


### PR DESCRIPTION
## Summary

1. Fix nightly build
2. Fix upstream-nightly build 

## Changes

- Removes buildstate conf on each build entry point
- Adds the repoUrl to be configured on the release branch tools 
- Fixes the instructions ref sent when creating packages 


Note: before creating this PR, not all test from the suite works


