### PR TITLE
Bundle element119/module-custom-admin-logo

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "aligent/magento2-pci-4-compatibility": "https://github.com/aligent/magento2-pci-4-compatibility.git",
     "creatuity/magento2-interceptors": "https://github.com/creatuity/magento2-interceptors.git",
+    "element119/module-custom-admin-logo": "https://github.com/element119/module-custom-admin-logo.git",
     "mage-os/inventory-metapackage": "https://github.com/mage-os/mageos-inventory.git",
     "mage-os/module-automatic-translation": "https://github.com/mage-os/module-automatic-translation.git",
     "mage-os/module-inventory-reservations-grid": "https://github.com/mage-os/module-inventory-reservations-grid.git",


### PR DESCRIPTION
I propose adding `element119/module-custom-admin-logo` as a bundled module. [https://github.com/element119/module-custom-admin-logo](https://github.com/element119/module-custom-admin-logo)

This module allows Magento admins to replace the default Magento logo on both the admin login screen and admin menu with a custom branded image, configurable directly from the admin panel without code changes.

# Implications
- Adds a new admin configuration group under `Stores → Settings → Configuration → Advanced → Admin → Admin Logos`
- Stores uploaded logo images within the Magento media directory
- No frontend impact — admin area only
- Logo will be unchanged by default (matching whatever the platform has -- Mage-OS, Magento, or Adobe Commerce)

# Risks
- Low risk; the module is lightweight with a single dependency (`magento/module-config`) and no database schema changes
- Uploaded image files are not validated beyond file type (jpg, jpeg, gif, png), using Magento uploader; SVG is explicitly not allowed to avoid script injection

# Benefits
- Enables merchants and agencies to brand the Magento admin panel without custom theme development
- Covers both the login page and the menu sidebar logo independently
- Easily reversible — default logos can be restored via the same config UI
- Built following Magento best practices; extensible by design
- Installable and removable cleanly via Composer

# PR
This PR results in the module being added as a pinned require of mage-os/product-community-edition like:

```
"element119/module-custom-admin-logo": "2.0.0",
```

which composer will then require via packagist, like any other third party package (Monolog, Laminas, Symphony, ...). The latest published version will be pinned at the time of each release.