### PR TITLE
Bundle n98/magerun2-dist

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -12,6 +12,7 @@
     "mage-os/module-theme-optimization": "https://github.com/mage-os/module-theme-optimization.git",
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
-    "mage-os/theme-adminhtml-m137": "https://github.com/mage-os/theme-adminhtml-m137.git"
+    "mage-os/theme-adminhtml-m137": "https://github.com/mage-os/theme-adminhtml-m137.git",
+    "n98/magerun2-dist": "https://github.com/netz98/n98-magerun2-dist.git"
   }
 }

--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -13,6 +13,6 @@
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/theme-adminhtml-m137": "https://github.com/mage-os/theme-adminhtml-m137.git",
-    "n98/magerun2-dist": "https://github.com/netz98/n98-magerun2-dist.git"
+    "n98/magerun2-dist": "^9.4"
   }
 }


### PR DESCRIPTION
This would add magerun2 as a bundled dependency for Mage-OS. https://github.com/netz98/n98-magerun2-dist

magerun2 is a widely used and very useful toolkit addon for managing Magento via CLI.

It will add ~7 MB to the installation size. Risks and implications should otherwise be minimal as it's installed to `vendor/bin/n98-magerun2` and only usable by SSH/CLI.

Magerun2 documentation: https://netz98.github.io/n98-magerun2/