### PR TITLE
fix: use usable kind for release integration checks

### DIFF
--- a/.github/workflows/build-mageos-release.yml
+++ b/.github/workflows/build-mageos-release.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: mage-os/github-actions/supported-version@main
         with:
           project: 'mage-os'
-          kind: 'all'
+          kind: 'usable'
         id: supported-version
   integration-check:
     name: "installation check"


### PR DESCRIPTION
## Summary
- Switch `build-mageos-release.yml` integration check from `kind: 'all'` to `kind: 'usable'` so uninstallable versions are excluded from the test matrix
- Companion to mage-os/github-actions#317 which adds the version exclusions

Fixes failures in: https://github.com/mage-os/generate-mirror-repo-js/actions/runs/24460658789

## Test plan
- [ ] Verify release workflow integration tests no longer include Mage-OS 2.2.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)