### PR TITLE
Bundle swissup/module-ignition

### DIFF
--- a/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
+++ b/resource/composer-templates/mage-os/product-community-edition/dependencies-template.json
@@ -15,6 +15,7 @@
     "mage-os/page-builder": "https://github.com/mage-os/mageos-magento2-page-builder.git",
     "mage-os/security-package": "https://github.com/mage-os/mageos-security-package.git",
     "mage-os/theme-adminhtml-m137": "https://github.com/mage-os/theme-adminhtml-m137.git",
-    "n98/magerun2-dist": "^9.4"
+    "n98/magerun2-dist": "^9.4",
+    "swissup/module-ignition": "https://github.com/swissup/module-ignition.git"
   }
 }


### PR DESCRIPTION
This would add https://github.com/swissup/module-ignition as a dev dependency of Mage-OS, starting with the 3.0 release.

This gives a meaningful improvement to exception pages in dev mode, including nice styling and code links to integrated IDEs, powered by https://github.com/spatie/ignition .

It takes effect only on developer mode. It leaves Magento's error handling unchanged in `default` and `production` modes.

It would be installed as a normal `require` dependency so that there's no discrepancy in `app/etc/config.php` for dev vs prod installs. (Ported from https://github.com/mage-os/mageos-magento2/pull/221)