### PR TITLE
Add release-prep skills for major-release branch coordination

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,8 @@
       "Bash(git diff *)",
       "Bash(git show *)",
       "Bash(curl *repo.mage-os.org*)",
-      "Bash(curl *preview-repo.mage-os.org*)"
+      "Bash(curl *preview-repo.mage-os.org*)",
+      "Bash(bash .claude/skills/*/scripts/*)"
     ]
   }
 }

--- a/.claude/skills/audit-release-branches/SKILL.md
+++ b/.claude/skills/audit-release-branches/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: audit-release-branches
+description: Use when preparing a Mage-OS major/minor release (e.g. "audit branches for 3.0", "which repos have release/3.x", "what still needs merging for 2.4.9", "find repos where develop is ahead of main") and you need a snapshot of release-branch coverage across every repo in the mage-os GitHub organization.
+---
+
+# Audit Release Branches Across the Mage-OS Org
+
+Produces a snapshot of branch state across every non `mirror-*` repo in the `mage-os` GitHub org. Used to answer two questions during release prep:
+
+1. **Which repos already have a release branch cut?** (e.g. `release/3.x`)
+2. **Which repos have `develop` or `2.4-develop` commits not yet merged to `main`/`master`?** Those are candidates for merge before the release goes out.
+
+## When to use
+
+- Starting prep for a Mage-OS major or minor release.
+- Verifying that all repos slated for the release have a release branch.
+- Identifying stale `develop` branches that need merging into trunk.
+- Producing data for the [[summarize-release-status]] skill.
+
+## Required tools
+
+- `gh` CLI (authenticated against an account with read access to `mage-os`)
+- `jq`
+
+## Scripts
+
+Both live in `scripts/` next to this SKILL.md.
+
+### `find-repos-with-branch.sh`
+
+Lists every non-archived, non `mirror-*` repo in the `mage-os` org and reports which have the given branch.
+
+```bash
+./find-repos-with-branch.sh [branch] [output-file]
+```
+
+Defaults: branch `release/3.x`, output `repos-with-<branch-slug>.txt`. Forks are included. The output file separates **matched** (with HEAD sha) from **missing**.
+
+### `find-unmerged-develop.sh`
+
+Scans the same repo list for repos where `develop` or `2.4-develop` exists alongside `main` or `master`, and the develop branch is ahead of trunk.
+
+```bash
+./find-unmerged-develop.sh [output-file] [--exclude-with-branch <branch>]
+```
+
+Use `--exclude-with-branch release/3.x` to skip repos where a release branch is already cut (those are tracked separately).
+
+The output file lists ahead-of-trunk repos with the `ahead`/`behind` commit counts so you can spot diverged branches that may need a rebase rather than a straight merge.
+
+## Typical workflow
+
+1. Pick a working directory for the release-prep artifacts (e.g. `tmp/release-process/`).
+2. Run `find-repos-with-branch.sh release/3.x` — captures which repos already have the release branch.
+3. Run `find-unmerged-develop.sh --exclude-with-branch release/3.x` — captures repos that still need a merge.
+4. Hand off the resulting `.txt` files to [[prep-release-prs]] (to open the PRs) or [[summarize-release-status]] (to produce a maintainer-facing update).
+
+## Notes
+
+- Archived repos are excluded (`--no-archived`).
+- `mirror-*` repos are excluded because they are downstream mirrors, not authoring repos.
+- Forks are included — some Mage-OS repos are forks of Magento upstream (e.g. `mageos-magento2`).
+- If you want a different release branch (e.g. `release/3.1.x`), pass it as the first arg to `find-repos-with-branch.sh`.

--- a/.claude/skills/audit-release-branches/scripts/find-repos-with-branch.sh
+++ b/.claude/skills/audit-release-branches/scripts/find-repos-with-branch.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Find all non mirror-* repositories in the mage-os GitHub organization
+# that have a given branch.
+#
+# Usage:
+#   ./find-repos-with-branch.sh [branch] [output-file]
+#
+# Defaults:
+#   branch       = release/3.x
+#   output-file  = repos-with-<branch-slug>.txt
+#
+set -euo pipefail
+
+ORG="mage-os"
+BRANCH="${1:-release/3.x}"
+SLUG="${BRANCH//\//-}"
+OUTFILE="${2:-repos-with-${SLUG}.txt}"
+
+command -v gh >/dev/null || { echo "gh CLI is required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+echo "Listing repositories in '${ORG}' (excluding mirror-*)..." >&2
+
+# Pull every non-archived repo name (forks included). --limit large enough to cover the org.
+mapfile -t REPOS < <(
+  gh repo list "$ORG" --limit 1000 --no-archived --json name \
+    | jq -r '.[].name' \
+    | grep -v '^mirror-' \
+    | sort
+)
+
+echo "Found ${#REPOS[@]} candidate repositories." >&2
+echo "Checking each for branch '${BRANCH}'..." >&2
+
+MATCHED=()
+MISSING=()
+ERRORED=()
+
+for repo in "${REPOS[@]}"; do
+  # gh api returns 0 with branch JSON on hit, non-zero on miss/error.
+  if out=$(gh api -H "Accept: application/vnd.github+json" \
+                  "repos/${ORG}/${repo}/branches/${BRANCH}" 2>&1); then
+    sha=$(echo "$out" | jq -r '.commit.sha' 2>/dev/null || echo "?")
+    MATCHED+=("${repo}	${sha}")
+    printf '  [hit ] %s @ %s\n' "$repo" "${sha:0:12}" >&2
+  else
+    if echo "$out" | grep -q 'Branch not found'; then
+      MISSING+=("$repo")
+      printf '  [miss] %s\n' "$repo" >&2
+    else
+      ERRORED+=("${repo}: ${out}")
+      printf '  [err ] %s\n' "$repo" >&2
+    fi
+  fi
+done
+
+{
+  echo "# Repositories in '${ORG}' with branch '${BRANCH}'"
+  echo "# Generated: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  echo "# Candidates scanned: ${#REPOS[@]} (mirror-* and archived excluded; forks included)"
+  echo "# Matched: ${#MATCHED[@]}  Missing: ${#MISSING[@]}  Errored: ${#ERRORED[@]}"
+  echo
+  echo "## Matched (repo<TAB>sha)"
+  printf '%s\n' "${MATCHED[@]:-}"
+  echo
+  echo "## Missing branch"
+  printf '%s\n' "${MISSING[@]:-}"
+  if [ "${#ERRORED[@]}" -gt 0 ]; then
+    echo
+    echo "## Errored"
+    printf '%s\n' "${ERRORED[@]}"
+  fi
+} > "$OUTFILE"
+
+echo >&2
+echo "Wrote results to: $OUTFILE" >&2
+echo "Matched ${#MATCHED[@]} / ${#REPOS[@]} repositories." >&2

--- a/.claude/skills/audit-release-branches/scripts/find-unmerged-develop.sh
+++ b/.claude/skills/audit-release-branches/scripts/find-unmerged-develop.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# For every non mirror-* repository in the mage-os org, look for cases where a
+# 'develop' or '2.4-develop' branch exists alongside 'main' or 'master', and
+# report when the develop branch is ahead of the trunk branch (i.e. carries
+# commits that have not been merged in).
+#
+# Usage:
+#   ./find-unmerged-develop.sh [output-file] [--exclude-with-branch <branch>]
+#
+# Pass --exclude-with-branch release/3.x to skip repos that already have that
+# release branch cut (i.e. work is already prepped there).
+#
+set -euo pipefail
+
+ORG="mage-os"
+OUTFILE=""
+EXCLUDE_BRANCH=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --exclude-with-branch) EXCLUDE_BRANCH="$2"; shift 2 ;;
+    *) OUTFILE="$1"; shift ;;
+  esac
+done
+OUTFILE="${OUTFILE:-develop-vs-trunk.txt}"
+
+DEV_BRANCHES=("develop" "2.4-develop")
+TRUNK_BRANCHES=("main" "master")
+
+command -v gh >/dev/null || { echo "gh CLI is required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+echo "Listing repositories in '${ORG}' (mirror-* excluded, forks included)..." >&2
+mapfile -t REPOS < <(
+  gh repo list "$ORG" --limit 1000 --no-archived --json name \
+    | jq -r '.[].name' \
+    | grep -v '^mirror-' \
+    | sort
+)
+echo "Found ${#REPOS[@]} candidate repositories." >&2
+
+branch_exists() {
+  # $1=repo  $2=branch — quiet HEAD; rc=0 if present
+  gh api -H "Accept: application/vnd.github+json" \
+    "repos/${ORG}/$1/branches/$2" >/dev/null 2>&1
+}
+
+AHEAD_ROWS=()    # repo<TAB>dev<TAB>trunk<TAB>ahead<TAB>behind
+EVEN_ROWS=()     # repo with matching branches but dev not ahead (informational)
+
+SKIPPED_ROWS=()  # repos excluded because they already have $EXCLUDE_BRANCH
+
+for repo in "${REPOS[@]}"; do
+  if [ -n "$EXCLUDE_BRANCH" ] && branch_exists "$repo" "$EXCLUDE_BRANCH"; then
+    SKIPPED_ROWS+=("$repo")
+    printf '  [skip ] %s (has %s)\n' "$repo" "$EXCLUDE_BRANCH" >&2
+    continue
+  fi
+  dev_found=""
+  trunk_found=""
+  for d in "${DEV_BRANCHES[@]}"; do
+    if branch_exists "$repo" "$d"; then dev_found="$d"; break; fi
+  done
+  [ -z "$dev_found" ] && continue
+  for t in "${TRUNK_BRANCHES[@]}"; do
+    if branch_exists "$repo" "$t"; then trunk_found="$t"; break; fi
+  done
+  [ -z "$trunk_found" ] && continue
+
+  # compare base=trunk head=dev -> ahead_by/behind_by are from the perspective
+  # of head relative to base, i.e. ahead_by = commits on dev not in trunk.
+  cmp=$(gh api -H "Accept: application/vnd.github+json" \
+    "repos/${ORG}/${repo}/compare/${trunk_found}...${dev_found}" \
+    --jq '{ahead: .ahead_by, behind: .behind_by, status}' 2>/dev/null || echo '')
+  if [ -z "$cmp" ]; then
+    printf '  [err ] %s (%s vs %s)\n' "$repo" "$dev_found" "$trunk_found" >&2
+    continue
+  fi
+  ahead=$(echo "$cmp" | jq -r '.ahead')
+  behind=$(echo "$cmp" | jq -r '.behind')
+  if [ "$ahead" -gt 0 ]; then
+    AHEAD_ROWS+=("${repo}	${dev_found}	${trunk_found}	${ahead}	${behind}")
+    printf '  [AHEAD] %s : %s is %s commits ahead of %s (behind %s)\n' \
+      "$repo" "$dev_found" "$ahead" "$trunk_found" "$behind" >&2
+  else
+    EVEN_ROWS+=("${repo}	${dev_found}	${trunk_found}	${ahead}	${behind}")
+    printf '  [even ] %s : %s == %s\n' "$repo" "$dev_found" "$trunk_found" >&2
+  fi
+done
+
+{
+  echo "# Repos in '${ORG}' where develop/2.4-develop has commits not in main/master"
+  echo "# Generated: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  echo "# Candidates scanned: ${#REPOS[@]}"
+  [ -n "$EXCLUDE_BRANCH" ] && echo "# Excluded (already have '${EXCLUDE_BRANCH}'): ${#SKIPPED_ROWS[@]}"
+  echo "# With develop AHEAD of trunk: ${#AHEAD_ROWS[@]}"
+  echo "# With develop matching/behind trunk: ${#EVEN_ROWS[@]}"
+  echo
+  echo "## Ahead (repo<TAB>dev-branch<TAB>trunk-branch<TAB>ahead<TAB>behind)"
+  printf '%s\n' "${AHEAD_ROWS[@]:-}"
+  echo
+  echo "## Even or behind (informational)"
+  printf '%s\n' "${EVEN_ROWS[@]:-}"
+  if [ -n "$EXCLUDE_BRANCH" ]; then
+    echo
+    echo "## Skipped (already have '${EXCLUDE_BRANCH}')"
+    printf '%s\n' "${SKIPPED_ROWS[@]:-}"
+  fi
+} > "$OUTFILE"
+
+echo >&2
+echo "Wrote results to: $OUTFILE" >&2
+echo "${#AHEAD_ROWS[@]} repos have develop commits not yet merged to trunk." >&2

--- a/.claude/skills/merge-upstream-tracking/SKILL.md
+++ b/.claude/skills/merge-upstream-tracking/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: merge-upstream-tracking
+description: Use when syncing upstream mirror content into the Mage-OS default branches across the org — e.g. "merge upstream into mage-os branches", "sync tracking branches", "merge mirror content into main/mage-os", "bring in upstream PHP 8.5 fixes".
+---
+
+# Merge Upstream Tracking Branches into Mage-OS Branches
+
+Merges each repo's upstream-tracking branch into its Mage-OS default branch, preserving Mage-OS CI files that upstream may have deleted. Used during release prep to reconcile diverged histories between the automated mirror sync and the Mage-OS branch.
+
+## Background
+
+Each `mageos-*` repo has two key branches:
+
+- **Mage-OS branch** (the default branch — `mage-os` or `main`): carries Mage-OS CI files and any org-specific changes.
+- **Tracking branch** (the other branch — `main`, `master`, `2.4-develop`, `2.21.x`, etc.): auto-synced daily from `mirror-*` repos via the `merge-upstream-changes` workflow.
+
+Over time these diverge: both get infra commits (Terraform, Sansec) independently, and upstream code changes land on the tracking branch but not the Mage-OS branch. This skill reconciles them.
+
+## When to use
+
+- Before a Mage-OS release, to bring upstream changes into the default branches.
+- When upstream has shipped PHP compatibility fixes, version bumps, or other changes that need to flow into the Mage-OS branches.
+- Periodically, to keep tracking/default branch divergence low.
+
+## When NOT to use
+
+- For the main `mageos-magento2` monorepo — that has its own merge workflow.
+- When a repo needs cherry-picks or rebases rather than a straight merge.
+- For repos outside the `mage-os` org.
+
+## Required tools
+
+- `gh` CLI authenticated with write access to `mage-os` repos
+- `jq`
+- `git`
+
+## Script
+
+`scripts/merge-upstream-tracking.sh` — defaults to **dry run**. Run it once to inspect the plan, then re-run with `--apply` to clone, merge, push, and create PRs.
+
+```bash
+# Dry run — scan all non-mirror repos, show what would be merged:
+./merge-upstream-tracking.sh
+
+# Apply — clone, merge, push, and create PRs:
+./merge-upstream-tracking.sh --apply
+
+# Only process specific repos:
+./merge-upstream-tracking.sh --apply --repo mageos-magento-zend-db --repo mageos-magento2-sample-data
+
+# Skip specific repos:
+./merge-upstream-tracking.sh --apply --exclude mageos-magento2
+
+# Custom branch name (default: merge/upstream-YYYY-MM-DD):
+./merge-upstream-tracking.sh --apply --branch merge/upstream-sync
+
+# Custom work directory:
+./merge-upstream-tracking.sh --apply --workdir /tmp/my-merge-work
+```
+
+Flags:
+- `--apply` — actually clone, merge, push, and create PRs (without this, no writes happen)
+- `--repo <name>` — only process this repo (repeatable; if omitted, scans all)
+- `--exclude <name>` — skip a repo (repeatable)
+- `--branch <name>` — PR branch name (default: `merge/upstream-YYYY-MM-DD`)
+- `--workdir <path>` — directory for cloned repos (default: `/tmp/merge-upstream-work`)
+- `--plan-file <path>` — override the plan output path
+
+## Behavior
+
+For each non `mirror-*`, non-archived repo in `mage-os`:
+
+1. Detect the **default branch** (the Mage-OS branch).
+2. Detect the **tracking branch** — the non-default branch that carries upstream content. Skips repos with fewer than 2 branches or where the only other branches are merge/release branches.
+3. Compare default..tracking — report `ahead_by` (commits on tracking not in default). Skip if tracking is not ahead.
+4. Check for an existing open PR with the same merge direction — skip if one exists.
+5. In `--apply` mode:
+   a. Clone the repo.
+   b. Check out the default branch, create the PR branch.
+   c. Merge the tracking branch.
+   d. Resolve conflicts: keep Mage-OS versions of CI files, take upstream for everything else.
+   e. Restore any CI files silently deleted by the merge.
+   f. Push and create a PR (uses `--repo` flag for fork repos).
+6. Write results to the plan file.
+
+### CI files preserved
+
+The script protects these Mage-OS CI files from deletion or overwrite during merge:
+
+- `.github/workflows/merge-upstream-changes.yml`
+- `.github/workflows/sansec-ecomscan.yml`
+- `CODEOWNERS`
+
+If a conflict occurs on these files, the Mage-OS (ours) version is kept. If the merge silently deletes them (because upstream removed them), they are restored from the default branch.
+
+## Typical workflow
+
+1. Run [[audit-release-branches]] to get a general picture of org state.
+2. `./merge-upstream-tracking.sh` — dry run; review the plan table.
+3. `./merge-upstream-tracking.sh --apply` — execute merges and create PRs.
+4. Review the PRs (especially repos with code changes, not just infra reconciliation).
+5. Report results via [[summarize-release-status]].
+
+## Notes
+
+- Fork repos (those forked from `mirror-*`) require `--repo` flag on `gh pr create` — the script handles this automatically.
+- Repos where the tracking branch has only infra commits (Terraform, Sansec) will produce PRs with merge commits but no file diff. These are safe to merge and reconcile the git history.
+- The `merge-upstream-changes` workflow runs daily. If this skill shows no repos need merging, the automated sync is working correctly and no manual intervention is needed.

--- a/.claude/skills/merge-upstream-tracking/scripts/merge-upstream-tracking.sh
+++ b/.claude/skills/merge-upstream-tracking/scripts/merge-upstream-tracking.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+#
+# Merge upstream-tracking branches into the Mage-OS default branch across the
+# mage-os org, preserving Mage-OS CI files.
+#
+# Each mageos-* repo has a default branch (mage-os or main) carrying CI files,
+# and a tracking branch (main, master, 2.4-develop, etc.) auto-synced from
+# mirror-* repos. This script merges tracking into default, resolving conflicts
+# in favour of Mage-OS CI files.
+#
+# Defaults to DRY RUN. Pass --apply to clone, merge, push, and create PRs.
+#
+# Usage:
+#   ./merge-upstream-tracking.sh
+#   ./merge-upstream-tracking.sh --apply
+#   ./merge-upstream-tracking.sh --apply --repo mageos-magento-zend-db --repo mageos-magento2-sample-data
+#   ./merge-upstream-tracking.sh --apply --exclude mageos-magento2
+#
+set -euo pipefail
+
+ORG="mage-os"
+APPLY=0
+BRANCH="merge/upstream-$(date +%Y-%m-%d)"
+WORKDIR="/tmp/merge-upstream-work"
+PLAN_FILE="upstream-merge-plan.txt"
+ONLY_REPOS=()
+EXCLUDE=()
+
+# Mage-OS CI files to preserve during merge
+CI_FILES=(
+  ".github/workflows/merge-upstream-changes.yml"
+  ".github/workflows/sansec-ecomscan.yml"
+  "CODEOWNERS"
+)
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply)    APPLY=1; shift ;;
+    --branch)   BRANCH="$2"; shift 2 ;;
+    --workdir)  WORKDIR="$2"; shift 2 ;;
+    --plan-file) PLAN_FILE="$2"; shift 2 ;;
+    --repo)     ONLY_REPOS+=("$2"); shift 2 ;;
+    --exclude)  EXCLUDE+=("$2"); shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+is_excluded() {
+  local r="$1" x
+  for x in "${EXCLUDE[@]:-}"; do
+    [ "$x" = "$r" ] && return 0
+  done
+  return 1
+}
+
+is_selected() {
+  # If --repo was used, only process those repos; otherwise process all.
+  [ "${#ONLY_REPOS[@]}" -eq 0 ] && return 0
+  local r="$1" x
+  for x in "${ONLY_REPOS[@]}"; do
+    [ "$x" = "$r" ] && return 0
+  done
+  return 1
+}
+
+command -v gh  >/dev/null || { echo "gh CLI is required" >&2; exit 1; }
+command -v jq  >/dev/null || { echo "jq is required" >&2; exit 1; }
+command -v git >/dev/null || { echo "git is required" >&2; exit 1; }
+
+# Known upstream-tracking branch names (exact match)
+TRACKING_NAMES=("main" "master" "develop" "2.4-develop")
+
+is_tracking_candidate() {
+  local b="$1"
+  # Exact match against known tracking names
+  for name in "${TRACKING_NAMES[@]}"; do
+    [ "$b" = "$name" ] && return 0
+  done
+  # Version-style branches: N.N.x, N.x, N.N-production, N.N-develop
+  [[ "$b" =~ ^[0-9]+\.[0-9]+\.x$ ]] && return 0
+  [[ "$b" =~ ^[0-9]+\.x$ ]] && return 0
+  [[ "$b" =~ ^[0-9]+\.[0-9]+-[a-z]+$ ]] && return 0
+  return 1
+}
+
+default_branch() {
+  gh api -H "Accept: application/vnd.github+json" \
+    "repos/${ORG}/$1" --jq '.default_branch'
+}
+
+is_fork() {
+  gh api -H "Accept: application/vnd.github+json" \
+    "repos/${ORG}/$1" --jq '.fork'
+}
+
+ahead_by() {
+  local result
+  result=$(gh api -H "Accept: application/vnd.github+json" \
+    "repos/${ORG}/$1/compare/$2...$3" --jq '.ahead_by' 2>/dev/null) || true
+  # Validate it's an integer (API may return JSON error object)
+  [[ "$result" =~ ^[0-9]+$ ]] && echo "$result" || echo ""
+}
+
+existing_pr() {
+  gh pr list --repo "${ORG}/$1" --base "$2" --head "$3" --state open \
+    --json number --jq '.[0].number // empty' 2>/dev/null || true
+}
+
+echo "Listing repositories in '${ORG}' (mirror-* excluded, forks included)..." >&2
+mapfile -t REPOS < <(
+  gh repo list "$ORG" --limit 1000 --no-archived --json name \
+    | jq -r '.[].name' \
+    | grep -v '^mirror-' \
+    | sort
+)
+echo "Found ${#REPOS[@]} candidate repositories." >&2
+
+PLAN=()       # repo<TAB>tracking<TAB>default<TAB>ahead<TAB>fork<TAB>existing-pr-or-none
+SKIPPED=()    # repo<TAB>reason
+
+for repo in "${REPOS[@]}"; do
+  if ! is_selected "$repo"; then continue; fi
+  if is_excluded "$repo"; then
+    SKIPPED+=("${repo}	excluded via --exclude")
+    continue
+  fi
+
+  defbranch=$(default_branch "$repo")
+
+  # List branches, find tracking branch (non-default, non-skip-prefix)
+  mapfile -t branches < <(
+    gh api -H "Accept: application/vnd.github+json" \
+      "repos/${ORG}/${repo}/branches" --paginate --jq '.[].name' 2>/dev/null
+  )
+
+  tracking=""
+  for b in "${branches[@]}"; do
+    [ "$b" = "$defbranch" ] && continue
+    is_tracking_candidate "$b" || continue
+    tracking="$b"
+    break
+  done
+
+  if [ -z "$tracking" ]; then
+    SKIPPED+=("${repo}	no tracking branch found")
+    continue
+  fi
+
+  ahead=$(ahead_by "$repo" "$defbranch" "$tracking")
+  if [ -z "$ahead" ]; then
+    SKIPPED+=("${repo}	compare failed (${tracking} vs ${defbranch})")
+    continue
+  fi
+  if [ "$ahead" -eq 0 ]; then
+    SKIPPED+=("${repo}	already merged (${tracking} == ${defbranch})")
+    continue
+  fi
+
+  fork=$(is_fork "$repo")
+  pr=$(existing_pr "$repo" "$defbranch" "$BRANCH")
+  PLAN+=("${repo}	${tracking}	${defbranch}	${ahead}	${fork}	${pr:-none}")
+done
+
+# Write plan file header
+{
+  echo "# Upstream tracking-branch merge plan"
+  echo "# Generated: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  echo "# PR branch: ${BRANCH}"
+  echo "# Mode: $([ $APPLY -eq 1 ] && echo APPLY || echo dry-run)"
+  echo "# Planned merges: ${#PLAN[@]}"
+  echo "# Skipped:        ${#SKIPPED[@]}"
+  echo
+  echo "## Planned (repo<TAB>tracking<TAB>default<TAB>ahead<TAB>fork<TAB>existing-pr)"
+  printf '%s\n' "${PLAN[@]:-}"
+  echo
+  echo "## Skipped (repo<TAB>reason)"
+  printf '%s\n' "${SKIPPED[@]:-}"
+} > "$PLAN_FILE"
+
+echo >&2
+echo "Plan written to: $PLAN_FILE" >&2
+echo "Planned: ${#PLAN[@]}   Skipped: ${#SKIPPED[@]}" >&2
+
+# Pretty print plan to stderr
+printf '\n%-55s %-15s %-10s %-7s %-6s %s\n' \
+  REPO TRACKING DEFAULT AHEAD FORK EXISTING-PR >&2
+printf '%-55s %-15s %-10s %-7s %-6s %s\n' \
+  "-------------------------------------------------------" \
+  "---------------" "----------" "-------" "------" "-----------" >&2
+for row in "${PLAN[@]:-}"; do
+  IFS=$'\t' read -r r t d a f p <<<"$row"
+  printf '%-55s %-15s %-10s %-7s %-6s %s\n' "$r" "$t" "$d" "$a" "$f" "$p" >&2
+done
+
+if [ $APPLY -eq 0 ]; then
+  echo >&2
+  echo "Dry run only. Re-run with --apply to clone, merge, push, and create PRs." >&2
+  exit 0
+fi
+
+# --- Apply mode ---
+
+mkdir -p "$WORKDIR"
+
+CREATED=()
+FAILED=()
+SKIPPED_EXISTING=()
+
+do_merge() {
+  local repo="$1" tracking="$2" defbranch="$3" fork="$4"
+  local repo_dir="${WORKDIR}/${repo}"
+
+  echo >&2
+  echo "=== ${repo}: ${tracking} -> ${defbranch} ===" >&2
+
+  # Clone
+  if [ -d "$repo_dir" ]; then
+    echo "  [info] Using existing clone at ${repo_dir}" >&2
+    git -C "$repo_dir" fetch origin >/dev/null 2>&1
+  else
+    gh repo clone "${ORG}/${repo}" "$repo_dir" -- --quiet 2>&1
+  fi
+
+  cd "$repo_dir"
+
+  # Clean up any prior merge branch
+  git checkout "$defbranch" -- 2>/dev/null || git checkout "$defbranch"
+  git reset --hard "origin/${defbranch}" >/dev/null 2>&1
+  git branch -D "$BRANCH" 2>/dev/null || true
+
+  # Create PR branch
+  git checkout -b "$BRANCH"
+
+  # Merge tracking branch
+  if git merge "origin/${tracking}" --no-edit 2>&1; then
+    echo "  [info] Merge succeeded cleanly" >&2
+  else
+    echo "  [info] Merge had conflicts, resolving..." >&2
+    local conflicted
+    conflicted=$(git diff --name-only --diff-filter=U 2>/dev/null || true)
+
+    for f in $conflicted; do
+      local is_ci=0
+      for ci in "${CI_FILES[@]}"; do
+        [ "$f" = "$ci" ] && { is_ci=1; break; }
+      done
+      if [ $is_ci -eq 1 ]; then
+        echo "    Keeping ours: $f" >&2
+        git checkout --ours "$f" && git add "$f"
+      else
+        echo "    Taking theirs: $f" >&2
+        git checkout --theirs "$f" && git add "$f"
+      fi
+    done
+    git commit --no-edit
+  fi
+
+  # Restore any CI files silently deleted by the merge
+  local restored=0
+  for f in "${CI_FILES[@]}"; do
+    if [ ! -f "$f" ]; then
+      if git show "${defbranch}:${f}" >/dev/null 2>&1; then
+        echo "    Restoring deleted: $f" >&2
+        git checkout "$defbranch" -- "$f"
+        restored=1
+      fi
+    fi
+  done
+  if [ $restored -eq 1 ]; then
+    git add "${CI_FILES[@]}" 2>/dev/null || true
+    git commit --amend --no-edit
+  fi
+
+  # Verify CI files
+  local missing=0
+  for f in "${CI_FILES[@]}"; do
+    if [ ! -f "$f" ]; then
+      echo "  [WARN] Missing after merge: $f" >&2
+      missing=1
+    fi
+  done
+  [ $missing -eq 0 ] && echo "  [ok  ] All CI files preserved" >&2
+
+  # Show diff summary
+  local stat
+  stat=$(git diff --stat "${defbranch}...${BRANCH}" 2>/dev/null || echo "(no file changes)")
+  if [ -n "$stat" ]; then
+    echo "  [info] Diff: ${stat}" >&2
+  else
+    echo "  [info] No file-level changes (history reconciliation only)" >&2
+  fi
+
+  # Push
+  git push -u origin "$BRANCH" --force-with-lease 2>&1
+
+  # Create PR (fork repos need --repo to target the correct repo)
+  local pr_body
+  pr_body=$(cat <<EOF
+## Summary
+- Sync tracking branch \`${tracking}\` into Mage-OS branch \`${defbranch}\`
+- Preserves all Mage-OS CI files (merge-upstream-changes, sansec-ecomscan, CODEOWNERS)
+
+Created by \`merge-upstream-tracking.sh\`.
+EOF
+)
+  local pr_url
+  if pr_url=$(gh pr create \
+      --repo "${ORG}/${repo}" \
+      --head "$BRANCH" \
+      --base "$defbranch" \
+      --title "Merge upstream (${tracking}) into ${defbranch}" \
+      --body "$pr_body" 2>&1); then
+    echo "  [ok  ] PR: ${pr_url}" >&2
+    CREATED+=("${repo}	${pr_url}")
+  else
+    echo "  [fail] PR creation failed: ${pr_url}" >&2
+    FAILED+=("${repo}	${pr_url}")
+  fi
+
+  cd - >/dev/null
+}
+
+echo >&2
+echo "Creating merges and PRs..." >&2
+
+for row in "${PLAN[@]:-}"; do
+  IFS=$'\t' read -r repo tracking defbranch ahead fork pr <<<"$row"
+  if [ "$pr" != "none" ]; then
+    SKIPPED_EXISTING+=("${repo}#${pr}")
+    echo "  [skip] ${repo}: PR #${pr} already open (${tracking} -> ${defbranch})" >&2
+    continue
+  fi
+
+  if do_merge "$repo" "$tracking" "$defbranch" "$fork"; then
+    :
+  else
+    FAILED+=("${repo}	merge or push failed")
+    echo "  [fail] ${repo}: merge or push failed" >&2
+  fi
+done
+
+# Append results to plan file
+{
+  echo
+  echo "## Apply results"
+  echo "# Created:  ${#CREATED[@]}"
+  echo "# Skipped (existing PR): ${#SKIPPED_EXISTING[@]}"
+  echo "# Failed:   ${#FAILED[@]}"
+  echo
+  echo "### Created"
+  printf '%s\n' "${CREATED[@]:-}"
+  echo
+  echo "### Skipped (existing PR)"
+  printf '%s\n' "${SKIPPED_EXISTING[@]:-}"
+  echo
+  echo "### Failed"
+  printf '%s\n' "${FAILED[@]:-}"
+} >> "$PLAN_FILE"
+
+echo >&2
+echo "Created ${#CREATED[@]} PRs. Skipped ${#SKIPPED_EXISTING[@]} (existing). Failed ${#FAILED[@]}." >&2
+echo "See: $PLAN_FILE" >&2

--- a/.claude/skills/prep-release-prs/SKILL.md
+++ b/.claude/skills/prep-release-prs/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: prep-release-prs
+description: Use when preparing a Mage-OS major/minor release and you need to open the batch of PRs that merge release/3.x (or other release branch) and unmerged develop branches into each repo's default branch — e.g. "open the release prep PRs", "create PRs for 3.0", "merge release/3.x into main everywhere", "open the develop-into-main PRs".
+---
+
+# Open Release-Prep PRs Across the Mage-OS Org
+
+Bulk-opens PRs across every relevant repo in the `mage-os` org to merge release content into trunk. Used after [[audit-release-branches]] has identified the repos in scope.
+
+For each repo it prefers `release/3.x` as the head branch if present; otherwise it falls back to `develop` or `2.4-develop`. The base is the repo's actual default branch (auto-detected — handles `main` vs `master`).
+
+## When to use
+
+- A Mage-OS release is being prepped and the audit shows N repos with merge-able content.
+- All repos to be touched are known and reviewed (see [[audit-release-branches]] output).
+- You want one PR per repo, opened consistently with a release-prep title and body.
+
+## When NOT to use
+
+- One-off merges — just open the PR manually with `gh pr create`.
+- Repos outside the `mage-os` org.
+- When repos need cherry-picks / rebases rather than straight merges — open those manually.
+
+## Required tools
+
+- `gh` CLI authenticated with write access to the target repos (an account with maintainer / admin on `mage-os`)
+- `jq`
+
+## Script
+
+`scripts/open-release-prs.sh` — defaults to **dry run**. Run it once without `--apply` to inspect the plan, then re-run with `--apply` to actually create PRs.
+
+```bash
+# Dry run for the current Mage-OS 3.0 cycle (uses defaults).
+./open-release-prs.sh
+
+# Override release branch + label for a future release (e.g. 4.0):
+./open-release-prs.sh \
+  --release-branch release/4.x \
+  --release-name "Mage-OS 4.0"
+
+# Apply: creates PRs via `gh pr create`.
+./open-release-prs.sh --apply
+
+# As drafts (recommended for large diffs):
+./open-release-prs.sh --apply --draft
+
+# Skip specific repos (e.g. one that's been pre-merged manually):
+./open-release-prs.sh --apply --exclude mageos-magento2
+```
+
+Flags:
+- `--release-branch <branch>` — release head branch to look for (default `release/3.x`)
+- `--release-name <label>` — human label used in PR title/body (default `Mage-OS 3.0`)
+- `--apply` — actually create the PRs (without this, no writes happen)
+- `--draft` — open as draft PRs
+- `--exclude <repo>` — skip a repo (repeatable)
+- `--plan-file <path>` — override the plan output path
+
+## Behavior
+
+For each non `mirror-*`, non-archived repo in `mage-os`:
+
+1. Determine head branch: prefer `<release-branch>` (e.g. `release/3.x`), else `develop`, else `2.4-develop`. Skip if none exist.
+2. Determine base: repo's default branch.
+3. Compare base..head — skip if head is not ahead of base (already merged).
+4. Look for an open PR with the same head/base — skip if one exists (idempotent).
+5. Otherwise, queue or open a PR titled `<release-name> prep: merge <head> into <base>` with a body explaining the merge intent and noting commits-ahead.
+
+The plan file (`release-prs-plan.txt` by default) records every planned, skipped, created, and failed PR with URLs.
+
+## Typical workflow
+
+1. Run [[audit-release-branches]] to know what's in scope.
+2. `./open-release-prs.sh` — dry run; verify the table matches expectations.
+3. Identify any repos to exclude (already-merged, requires manual care, etc.).
+4. `./open-release-prs.sh --apply [--draft] [--exclude REPO ...]`
+5. Hand the resulting PR URLs to maintainers for review (see [[summarize-release-status]] for the maintainer-facing message).
+
+## Notes
+
+- Defaults target the current cycle (`release/3.x`, `Mage-OS 3.0`). For future releases pass `--release-branch` and `--release-name` instead of editing the script.
+- Auto-detects `main` vs `master` per repo via the GitHub API — do not hardcode.
+- Large diverged branches (high `behind` count) may need rebase rather than merge; open those manually rather than letting this script create an unmergeable PR.

--- a/.claude/skills/prep-release-prs/scripts/open-release-prs.sh
+++ b/.claude/skills/prep-release-prs/scripts/open-release-prs.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+#
+# Open PRs to merge release branches into trunk across the mage-os org as
+# part of a Mage-OS release preparation cycle.
+#
+# For every non mirror-* repo, two cases produce a PR:
+#   1. Repo has the configured release branch (e.g. release/3.x) -> PR it into default
+#   2. Repo has no release branch but has 'develop' or '2.4-develop' that is
+#      ahead of 'main'/'master'                                 -> PR dev into trunk
+#
+# Defaults to DRY RUN. Pass --apply to actually create the PRs.
+#
+# Usage:
+#   ./open-release-prs.sh \
+#       --release-branch release/3.x \
+#       --release-name "Mage-OS 3.0"
+#   ./open-release-prs.sh --release-branch release/4.x --release-name "Mage-OS 4.0" --apply --draft
+#
+# Defaults: release-branch=release/3.x, release-name="Mage-OS 3.0"
+#
+set -euo pipefail
+
+ORG="mage-os"
+APPLY=0
+DRAFT=0
+PLAN_FILE="release-prs-plan.txt"
+RELEASE_BRANCH="release/3.x"
+RELEASE_NAME="Mage-OS 3.0"
+EXCLUDE=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply) APPLY=1; shift ;;
+    --draft) DRAFT=1; shift ;;
+    --plan-file) PLAN_FILE="$2"; shift 2 ;;
+    --release-branch) RELEASE_BRANCH="$2"; shift 2 ;;
+    --release-name) RELEASE_NAME="$2"; shift 2 ;;
+    --exclude) EXCLUDE+=("$2"); shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+is_excluded() {
+  local r="$1" x
+  for x in "${EXCLUDE[@]:-}"; do
+    [ "$x" = "$r" ] && return 0
+  done
+  return 1
+}
+
+command -v gh >/dev/null || { echo "gh CLI is required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+DEV_BRANCHES=("develop" "2.4-develop")
+
+branch_exists() {
+  gh api -H "Accept: application/vnd.github+json" \
+    "repos/${ORG}/$1/branches/$2" >/dev/null 2>&1
+}
+
+default_branch() {
+  gh api -H "Accept: application/vnd.github+json" \
+    "repos/${ORG}/$1" --jq '.default_branch'
+}
+
+ahead_by() {
+  # $1=repo $2=base $3=head -> echoes ahead_by or empty on error
+  gh api -H "Accept: application/vnd.github+json" \
+    "repos/${ORG}/$1/compare/$2...$3" --jq '.ahead_by' 2>/dev/null || true
+}
+
+existing_pr() {
+  # $1=repo $2=base $3=head -> echoes PR number if open, else empty
+  gh pr list --repo "${ORG}/$1" --base "$2" --head "$3" --state open \
+    --json number --jq '.[0].number // empty' 2>/dev/null || true
+}
+
+echo "Listing repositories in '${ORG}' (mirror-* excluded, forks included)..." >&2
+mapfile -t REPOS < <(
+  gh repo list "$ORG" --limit 1000 --no-archived --json name \
+    | jq -r '.[].name' \
+    | grep -v '^mirror-' \
+    | sort
+)
+echo "Found ${#REPOS[@]} candidate repositories." >&2
+
+PLAN=()       # repo<TAB>head<TAB>base<TAB>ahead<TAB>existing-pr-or-none
+SKIPPED=()    # repo<TAB>reason
+
+for repo in "${REPOS[@]}"; do
+  if is_excluded "$repo"; then
+    SKIPPED+=("${repo}	excluded via --exclude")
+    continue
+  fi
+  head=""
+  if branch_exists "$repo" "$RELEASE_BRANCH"; then
+    head="$RELEASE_BRANCH"
+  else
+    for d in "${DEV_BRANCHES[@]}"; do
+      if branch_exists "$repo" "$d"; then head="$d"; break; fi
+    done
+  fi
+  [ -z "$head" ] && continue
+
+  base=$(default_branch "$repo")
+  if [ "$base" = "$head" ]; then
+    SKIPPED+=("${repo}	head==base (${head})")
+    continue
+  fi
+
+  ahead=$(ahead_by "$repo" "$base" "$head")
+  if [ -z "$ahead" ]; then
+    SKIPPED+=("${repo}	compare failed (${head} vs ${base})")
+    continue
+  fi
+  if [ "$ahead" -eq 0 ]; then
+    SKIPPED+=("${repo}	already merged (${head} == ${base})")
+    continue
+  fi
+
+  pr=$(existing_pr "$repo" "$base" "$head")
+  PLAN+=("${repo}	${head}	${base}	${ahead}	${pr:-none}")
+done
+
+# Write plan file
+{
+  echo "# ${RELEASE_NAME} release-prep PR plan"
+  echo "# Generated: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  echo "# Mode: $([ $APPLY -eq 1 ] && echo APPLY || echo dry-run)"
+  echo "# Planned PRs: ${#PLAN[@]}"
+  echo "# Skipped:     ${#SKIPPED[@]}"
+  echo
+  echo "## Planned (repo<TAB>head<TAB>base<TAB>ahead<TAB>existing-pr)"
+  printf '%s\n' "${PLAN[@]:-}"
+  echo
+  echo "## Skipped (repo<TAB>reason)"
+  printf '%s\n' "${SKIPPED[@]:-}"
+} > "$PLAN_FILE"
+
+echo >&2
+echo "Plan written to: $PLAN_FILE" >&2
+echo "Planned: ${#PLAN[@]}   Skipped: ${#SKIPPED[@]}" >&2
+
+# Pretty print plan to stderr
+printf '\n%-50s %-15s %-10s %-7s %s\n' REPO HEAD BASE AHEAD EXISTING-PR >&2
+printf '%-50s %-15s %-10s %-7s %s\n' \
+  "--------------------------------------------------" \
+  "---------------" "----------" "-------" "-----------" >&2
+for row in "${PLAN[@]:-}"; do
+  IFS=$'\t' read -r r h b a p <<<"$row"
+  printf '%-50s %-15s %-10s %-7s %s\n' "$r" "$h" "$b" "$a" "$p" >&2
+done
+
+if [ $APPLY -eq 0 ]; then
+  echo >&2
+  echo "Dry run only. Re-run with --apply to create PRs." >&2
+  exit 0
+fi
+
+echo >&2
+echo "Creating PRs..." >&2
+DRAFT_FLAG=()
+[ $DRAFT -eq 1 ] && DRAFT_FLAG=(--draft)
+
+CREATED=()
+FAILED=()
+SKIPPED_EXISTING=()
+
+for row in "${PLAN[@]:-}"; do
+  IFS=$'\t' read -r repo head base ahead pr <<<"$row"
+  if [ "$pr" != "none" ]; then
+    SKIPPED_EXISTING+=("${repo}#${pr}")
+    echo "  [skip] ${repo}: PR #${pr} already open (${head} -> ${base})" >&2
+    continue
+  fi
+
+  title="${RELEASE_NAME} prep: merge ${head} into ${base}"
+  body=$(cat <<EOF
+Merge \`${head}\` into \`${base}\` as part of **${RELEASE_NAME}** release preparation.
+
+- Head: \`${head}\`
+- Base: \`${base}\`
+- Commits ahead at time of PR creation: ${ahead}
+
+This PR was opened by a release-prep automation script. Please review the diff
+before merging — some branches have diverged from trunk and may need a rebase
+or selective merge rather than a straight merge.
+EOF
+)
+
+  if url=$(gh pr create --repo "${ORG}/${repo}" \
+              --base "$base" --head "$head" \
+              --title "$title" --body "$body" \
+              "${DRAFT_FLAG[@]}" 2>&1); then
+    CREATED+=("${repo}	${url}")
+    echo "  [ok  ] ${repo}: ${url}" >&2
+  else
+    FAILED+=("${repo}	${url}")
+    echo "  [fail] ${repo}: ${url}" >&2
+  fi
+done
+
+{
+  echo
+  echo "## Apply results"
+  echo "# Created:  ${#CREATED[@]}"
+  echo "# Skipped (existing PR): ${#SKIPPED_EXISTING[@]}"
+  echo "# Failed:   ${#FAILED[@]}"
+  echo
+  echo "### Created"
+  printf '%s\n' "${CREATED[@]:-}"
+  echo
+  echo "### Skipped (existing PR)"
+  printf '%s\n' "${SKIPPED_EXISTING[@]:-}"
+  echo
+  echo "### Failed"
+  printf '%s\n' "${FAILED[@]:-}"
+} >> "$PLAN_FILE"
+
+echo >&2
+echo "Created ${#CREATED[@]} PRs. Skipped ${#SKIPPED_EXISTING[@]} (existing). Failed ${#FAILED[@]}." >&2
+echo "See: $PLAN_FILE" >&2

--- a/.claude/skills/summarize-release-status/SKILL.md
+++ b/.claude/skills/summarize-release-status/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: summarize-release-status
+description: Use when the user asks for a Mage-OS release-prep status update to share with other maintainers — e.g. "summarize release status for Discord", "write a maintainer update", "status of 3.0 prep", "draft a status message about the release branches", or after running the branch audit / PR-prep skills and the user wants the takeaway formatted for sharing.
+---
+
+# Summarize Release Status for Maintainers
+
+Produces a concise, copy-paste-ready maintainer update (Discord-style) summarizing the state of branch coverage and PR readiness for a Mage-OS release. Consumes the output files from [[audit-release-branches]] and/or [[prep-release-prs]].
+
+## When to use
+
+- After running an audit / PR-prep pass, when the user wants a shareable update.
+- Periodic check-ins to maintainers about release progress.
+- Catching up new maintainers on where the release stands.
+
+## When NOT to use
+
+- Full release notes (use [[analyze-release-preview]] instead).
+- Per-PR status (just link the PRs directly).
+- Internal-only tracking (a plain `.txt` file is fine).
+
+## Input data
+
+Whichever of these exist in the working directory:
+
+- `repos-with-release-<X>.x.txt` — output of `find-repos-with-branch.sh`
+- `develop-vs-trunk.txt` — output of `find-unmerged-develop.sh`
+- `release-prs-plan.txt` — output of `open-release-prs.sh` (especially after `--apply` so it contains PR URLs)
+
+## Output shape
+
+Markdown chunks suitable for Discord. Aim for short, scannable, no emoji unless the user asks for them. Structure:
+
+1. **One-sentence header** — what release, what was scanned.
+2. **`release/3.x` already cut** — bulleted list of repos.
+3. **`develop` / `2.4-develop` ahead of trunk** — table with repo, branch, commits ahead. Order alphabetically.
+4. **Next step / status** — what automation has run, what's pending, exclusions and why.
+5. **Pointer** — where the scripts and outputs live for anyone who wants to re-run.
+
+Keep the whole thing under ~25 lines so it fits in one Discord message. If a section is empty, omit it rather than printing "(none)".
+
+## Example
+
+The version numbers below are illustrative for the 3.0 cycle — substitute the actual release the user is preparing (4.0, 5.0, …).
+
+```
+**Mage-OS 3.0 release prep — branch status**
+
+Scanned all non-mirror repos in `mage-os` (65 total, forks included).
+
+**`release/3.x` already cut (5 repos, ready to go):**
+- generate-mirror-repo-js
+- mageos-inventory
+- mageos-magento2
+- mageos-magento2-page-builder
+- mageos-security-package
+
+**`develop` / `2.4-develop` ahead of `main` (need merging for 3.0):**
+| Repo | Branch | Commits ahead |
+|---|---|---|
+| mageos-PHPCompatibilityFork | develop | 8 |
+| mageos-adobe-stock-integration | develop | 33 |
+| ...
+
+**Next step:** PR automation ready (12 PRs planned). `mageos-magento2` excluded — pre-merged manually both directions. Will run after maintainer review.
+```
+
+## Tips
+
+- Always quote the absolute commit-ahead numbers — maintainers use them to gauge merge complexity.
+- Call out diverged branches (high `behind` count) explicitly — they may not merge cleanly.
+- If [[prep-release-prs]] has been applied, include a flat list of PR URLs at the end so reviewers can jump in directly.
+- Re-running the audit before writing the summary keeps numbers current; counts change as PRs merge.


### PR DESCRIPTION
## Summary

Adds Claude Code skills under `.claude/skills/` to support coordinating a Mage-OS major release across all repos in the `mage-os` org. Built and used during 3.0 prep; parameterized so they remain usable for 4.0 / 5.0 / etc.

### Skills

- **`audit-release-branches`** — scans every non `mirror-*` repo for:
  - presence of a configurable release branch (default `release/3.x`)
  - `develop` / `2.4-develop` branches that are ahead of `main` / `master` and may still need merging
- **`prep-release-prs`** — bulk-opens PRs that merge each repo's release/dev branch into its default branch. Defaults to **dry run**; `--apply` actually opens PRs. Supports `--draft`, `--exclude <repo>` (repeatable), and `--release-branch` / `--release-name` for future cycles.
- **`merge-upstream-tracking`** — merges each repo's upstream-tracking branch (auto-synced from `mirror-*` repos) into its Mage-OS default branch, preserving CI files (merge-upstream-changes, sansec-ecomscan, CODEOWNERS) that upstream deletes during mirror sync. Dry-run by default; `--apply` clones, merges with conflict resolution, pushes, and opens PRs. Supports `--repo` (target specific repos) and `--exclude`. Used during 2.4.9 prep to sync PHP 8.5 fixes and version bumps across 13 repos.
- **`summarize-release-status`** — turns the audit and PR-plan outputs into a Discord-style maintainer update.

Each skill is self-contained (`SKILL.md` + `scripts/` subdir, matching the existing `analyze-release-preview` / `add-release-history` layout) and cross-references the others via `[[name]]` so the workflow is discoverable from any entry point.

## Dependencies

- `gh` CLI (authenticated against an account with read / write access to `mage-os`)
- `jq`
- `git` (for `merge-upstream-tracking` only — it clones repos to do local merges)

## Test plan

- [x] `audit-release-branches/scripts/find-repos-with-branch.sh release/3.x` — produces correct list (5 repos with `release/3.x`)
- [x] `audit-release-branches/scripts/find-unmerged-develop.sh --exclude-with-branch release/3.x` — produces correct list (7 repos)
- [x] `prep-release-prs/scripts/open-release-prs.sh` — dry-run matches expected 12-PR plan
- [x] `prep-release-prs/scripts/open-release-prs.sh --apply` — verified by opening the actual 3.0-prep PRs across 12 repos
- [x] `prep-release-prs/scripts/open-release-prs.sh --release-branch release/4.x --release-name "Mage-OS 4.0"` — falls back to develop branches as expected for a fresh cycle
- [x] `merge-upstream-tracking/scripts/merge-upstream-tracking.sh` — dry-run correctly identifies repos needing upstream merges, auto-detects tracking/default branch pairs, filters out feature branches
- [x] `merge-upstream-tracking/scripts/merge-upstream-tracking.sh --apply` — verified by merging 13 repos during 2.4.9 upstream sync (PHP 8.5 fixes, version bumps, infra reconciliation); all CI files preserved
- [x] Reviewer: confirm script defaults (`release/3.x`, `Mage-OS 3.0`) are appropriate for the next release cycle or whether they should be bumped before merge

## Notes

- Drafted while the 3.0 release-prep PRs were being opened; no PII, credentials, or hardcoded local paths in the committed files.
- Defaults target the current cycle but every release-specific value is overridable at the command line — no future maintainer needs to edit the scripts for 4.0 / 5.0.
