### PR TITLE
Remove ext-ftp from mage-os-minimal test PHP_EXTENSIONS

### DIFF
--- a/tests/unit/build-metapackage/mage-os-minimal.test.js
+++ b/tests/unit/build-metapackage/mage-os-minimal.test.js
@@ -32,7 +32,6 @@ const PHP_EXTENSIONS = [
   'ext-ctype',
   'ext-curl',
   'ext-dom',
-  'ext-ftp',
   'ext-gd',
   'ext-hash',
   'ext-iconv',


### PR DESCRIPTION
## Summary
- Fixes test failures on PR #320 (release/3.x → main).
- Commit 8665c0a3 removed `ext-ftp` from the preserve set in `src/build-metapackage/mage-os-minimal.js` but did not update the tests added in 196b9922.
- The stale `PHP_EXTENSIONS` array in `tests/unit/build-metapackage/mage-os-minimal.test.js` still included `'ext-ftp'`, causing two assertions to fail:
  - `should preserve all required PHP extensions`
  - `should preserve exactly the packages in the preserve list, no more, no less`

## Test plan
- [x] `npx jest tests/unit/build-metapackage/mage-os-minimal.test.js` — 29/29 pass locally
- [ ] CI green on this PR
- [ ] CI green on PR #320 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)