### PR TITLE
Fix nightly install failure on third-party magento/* dependencies

### DIFF
--- a/src/make/mageos-nightly.js
+++ b/src/make/mageos-nightly.js
@@ -1,11 +1,15 @@
 const repo = require('./../repository');
 const parseOptions = require('parse-options');
 const {setArchiveBaseDir} = require('./../package-modules');
-const {processNightlyBuildInstructions} = require('./../release-branch-build-tools');
+const {
+  processNightlyBuildInstructions,
+  determineLatestUpstreamMagentoRelease,
+} = require('./../release-branch-build-tools');
+const {getPackageVersionMap} = require('./../release-build-tools');
 const {buildConfig: branchBuildInstructions} = require('./../build-config/mageos-nightly-build-config');
 
 const options = parseOptions(
-  `$outputDir $gitRepoDir $repoUrl @help|h`,
+  `$outputDir $gitRepoDir $repoUrl $upstreamRelease @help|h`,
   process.argv
 );
 
@@ -15,11 +19,13 @@ if (options.help) {
 
 Usage:
   node src/make/mageos-nightly.js [OPTIONS]
-  
+
 Options:
-  --outputDir=   Dir to contain the built packages (default: packages)
-  --gitRepoDir=  Dir to clone repositories into (default: repositories)
-  --repoUrl=     Composer repository URL to use in base package (default: https://repo.mage-os.org/)
+  --outputDir=        Dir to contain the built packages (default: packages)
+  --gitRepoDir=       Dir to clone repositories into (default: repositories)
+  --repoUrl=          Composer repository URL to use in base package (default: https://repo.mage-os.org/)
+  --upstreamRelease=  Upstream Magento Open Source release used to populate the replace map
+                      of nightly mage-os/* packages. Auto-detected from mirror.mage-os.org if omitted.
 `);
   process.exit(1);
 }
@@ -35,5 +41,18 @@ for (const instruction of branchBuildInstructions) {
   instruction.vendor = 'mage-os';
 }
 
-processNightlyBuildInstructions(branchBuildInstructions, options.repoUrl || 'https://nightly.mage-os.org/');
+(async () => {
+  try {
+    const upstreamRelease = options.upstreamRelease || await determineLatestUpstreamMagentoRelease();
+    console.log(`Using upstream Magento release ${upstreamRelease} as source of replace versions`);
+    const replaceVersions = await getPackageVersionMap(upstreamRelease, {skipSampleData: true});
+
+    await processNightlyBuildInstructions(branchBuildInstructions, options.repoUrl || 'https://nightly.mage-os.org/', {
+      replaceVersions,
+    });
+  } catch (exception) {
+    console.error(exception);
+    process.exit(1);
+  }
+})();
 

--- a/src/package-modules.js
+++ b/src/package-modules.js
@@ -131,11 +131,18 @@ function getVersionStability(version) {
  * configuration and should stay resolvable from their original vendor on Packagist.
  * The package name itself (composerConfig.name) is always renamed regardless.
  *
+ * When replaceVersions is provided and the package is renamed from a magento/* name, a `replace`
+ * entry is added pointing back to the original magento/* name with the real upstream Magento
+ * version. This is what lets third-party packages still requiring magento/* by the original
+ * name (e.g. `element119/module-custom-admin-logo` requiring `magento/framework`) resolve
+ * against the renamed mage-os/* package.
+ *
  * @param {Object} composerConfig - Parsed composer.json object, mutated in place
  * @param {String} vendor
  * @param {Object.<string, string>} [dependencyVersions] - Map of renamed-vendor package names to version strings
+ * @param {Object.<string, string>} [replaceVersions] - Map of original magento/* package names to upstream versions
  */
-function applyVendorRename(composerConfig, vendor, dependencyVersions) {
+function applyVendorRename(composerConfig, vendor, dependencyVersions, replaceVersions) {
   if (!vendor || vendor === 'magento') return;
   const toVendor = name => name.replace(/^magento\//, `${vendor}/`);
   const shouldRename = name => {
@@ -144,6 +151,7 @@ function applyVendorRename(composerConfig, vendor, dependencyVersions) {
     return toVendor(name) in dependencyVersions;
   };
   const rename = name => shouldRename(name) ? toVendor(name) : name;
+  const originalName = composerConfig.name;
   composerConfig.name = toVendor(composerConfig.name);
   for (const depType of ['require', 'require-dev', 'suggest', 'replace', 'conflict']) {
     if (!composerConfig[depType]) continue;
@@ -152,6 +160,10 @@ function applyVendorRename(composerConfig, vendor, dependencyVersions) {
       renamed[rename(pkg)] = val;
     }
     composerConfig[depType] = renamed;
+  }
+  if (replaceVersions && originalName && originalName.startsWith('magento/') && replaceVersions[originalName]) {
+    composerConfig.replace = composerConfig.replace || {};
+    composerConfig.replace[originalName] = replaceVersions[originalName];
   }
 }
 
@@ -320,7 +332,7 @@ async function createPackageForRef(instruction, pkg, release) {
   let composerConfig = JSON.parse(composerJson);
 
   if (instruction.vendor && instruction.vendor !== 'magento') {
-    applyVendorRename(composerConfig, instruction.vendor, release.dependencyVersions);
+    applyVendorRename(composerConfig, instruction.vendor, release.dependencyVersions, release.replaceVersions);
   }
 
   let name, version;
@@ -600,7 +612,7 @@ async function createMetaPackageFromRepoDir(instruction, pkg, release) {
   ));
 
   if (instruction.vendor && instruction.vendor !== 'magento') {
-    applyVendorRename(composerConfig, instruction.vendor, release.dependencyVersions);
+    applyVendorRename(composerConfig, instruction.vendor, release.dependencyVersions, release.replaceVersions);
   }
 
   let {version, name} = composerConfig;
@@ -672,7 +684,7 @@ async function createMetaPackage(instruction, metapackage, release) {
   // For release builds the transforms already handle renaming, so applyVendorRename finds no
   // magento/ deps to rename and leaves the config unchanged.
   if (instruction.vendor && instruction.vendor !== 'magento') {
-    applyVendorRename(composerConfig, instruction.vendor, release.dependencyVersions);
+    applyVendorRename(composerConfig, instruction.vendor, release.dependencyVersions, release.replaceVersions);
     // Re-run setDependencyVersions after rename so that deps now keyed under the target vendor
     // (e.g. mage-os/composer) can be matched against the dependencyVersions map, which uses
     // renamed (mage-os/) keys.

--- a/src/release-branch-build-tools.js
+++ b/src/release-branch-build-tools.js
@@ -13,7 +13,6 @@ const repositoryBuildDefinition = require("./type/repository-build-definition");
 const buildState = require("./type/build-state");
 const {fetchPackagistList} = require("./packagist");
 const {httpSlurp, compareVersions} = require("./utils");
-const {getPackageVersionMap} = require("./release-build-tools");
 
 const DEFAULT_UPSTREAM_MIRROR_URL = 'https://mirror.mage-os.org';
 const UPSTREAM_VERSION_REFERENCE_PACKAGE = 'magento/product-community-edition';

--- a/src/release-branch-build-tools.js
+++ b/src/release-branch-build-tools.js
@@ -12,6 +12,14 @@ const {
 const repositoryBuildDefinition = require("./type/repository-build-definition");
 const buildState = require("./type/build-state");
 const {fetchPackagistList} = require("./packagist");
+const {httpSlurp, compareVersions} = require("./utils");
+const {getPackageVersionMap} = require("./release-build-tools");
+
+const DEFAULT_UPSTREAM_MIRROR_URL = 'https://mirror.mage-os.org';
+const UPSTREAM_VERSION_REFERENCE_PACKAGE = 'magento/product-community-edition';
+// Matches plain stable releases (X.Y, X.Y.Z) and patch suffixes (-p1, -p2.3),
+// rejecting pre-release labels like -alpha, -beta, -rc, -dev.
+const STABLE_VERSION_RE = /^v?\d+\.\d+(?:\.\d+)?(?:-p\d+(?:\.\d+)?)?$/i;
 
 /**
  * @param {repositoryBuildDefinition} instruction
@@ -155,15 +163,47 @@ async function processBuildInstruction(instruction, release) {
 }
 
 /**
+ * Picks the highest stable magento/product-community-edition version published on
+ * the given composer repo. Nightly mage-os/* packages use that version when writing
+ * their `replace` map so third-party packages requiring magento/* by the original
+ * name can resolve against them (e.g. `magento/framework >=103.0.7`).
+ *
+ * @param {string} mirrorUrl
+ * @returns {Promise<string>}
+ */
+async function determineLatestUpstreamMagentoRelease(mirrorUrl = DEFAULT_UPSTREAM_MIRROR_URL) {
+  const url = `${mirrorUrl.replace(/\/$/, '')}/p2/${UPSTREAM_VERSION_REFERENCE_PACKAGE}.json`;
+  const body = await httpSlurp(url);
+  let data;
+  try {
+    data = JSON.parse(body);
+  } catch (err) {
+    throw new Error(`Could not parse package metadata from ${url}: ${err.message}`);
+  }
+  const versions = (data?.packages?.[UPSTREAM_VERSION_REFERENCE_PACKAGE] || [])
+    .map(v => v.version)
+    .filter(v => STABLE_VERSION_RE.test(v));
+  if (versions.length === 0) {
+    throw new Error(`No stable ${UPSTREAM_VERSION_REFERENCE_PACKAGE} versions found at ${url}`);
+  }
+  versions.sort(compareVersions);
+  return versions[versions.length - 1];
+}
+
+/**
  * @param {Array<repositoryBuildDefinition>} instructions
+ * @param {string} repoUrl
+ * @param {{replaceVersions?: Object<string, string>}} [options]
  * @returns {Promise<void>}
  */
-async function processNightlyBuildInstructions(instructions, repoUrl) {
+async function processNightlyBuildInstructions(instructions, repoUrl, options = {}) {
   const releaseSuffix = getReleaseDateString();
+
   let release = new buildState({
     composerRepoUrl: repoUrl,
     fallbackVersion: transformVersionsToNightlyBuildVersion('0.0.1', releaseSuffix), // version to use for previously unreleased packages
     dependencyVersions: await getPackageVersionsForBuildInstructions(instructions, releaseSuffix),
+    replaceVersions: options.replaceVersions || {},
   });
 
   await fetchPackagistList('mage-os');
@@ -175,6 +215,7 @@ async function processNightlyBuildInstructions(instructions, repoUrl) {
 
 module.exports = {
   processNightlyBuildInstructions,
+  determineLatestUpstreamMagentoRelease,
   getPackageVersionsForBuildInstructions,
   transformVersionsToNightlyBuildVersions,
   calcNightlyBuildPackageBaseVersion,

--- a/src/release-build-tools.js
+++ b/src/release-build-tools.js
@@ -36,15 +36,11 @@ async function composerCreateMagentoProject(version) {
       console.log(`Running ${command}`)
       const bufferBytes = 4 * 1024 * 1024; // 4M
       childProcess.exec(command, {maxBuffer: bufferBytes}, (error, stdout, stderr) => {
-        //if (stderr && stderr.includes('Warning: The lock file is not up-to-date with the latest changes in composer.json')) stderr = '';
-        if (stderr && stderr.includes('Generating autoload files')) stderr = '';
-        if (stderr) stderr = stderr.split('\n').filter(line => !line.startsWith('Deprecation Notice:')).join('\n').trim();
         if (error) {
-          reject(`Error executing command: ${error.message}`)
+          reject(`Error executing command: ${error.message}\n${stdout}\n${stderr}`)
+          return;
         }
-        if (stderr) {
-          reject(`[error] ${stderr}`)
-        }
+        // composer & git write progress/warnings to stderr; trust the exit code.
         resolve(workDir)
       })
     }
@@ -58,12 +54,9 @@ async function installSampleData(dir) {
   const bufferBytes = 4 * 1024 * 1024; // 4M
   const output = await (new Promise((resolve, reject) => {
     childProcess.exec(listCommand, {maxBuffer: bufferBytes, cwd: dir}, (error, stdout, stderr) => {
-      if (stderr) stderr = stderr.split('\n').filter(line => !line.startsWith('Deprecation Notice:')).join('\n').trim();
       if (error) {
-        reject(`Error executing command: ${error.message}`)
-      }
-      if (stderr) {
-        reject(`[error] ${stderr}`)
+        reject(`Error executing command: ${error.message}\n${stdout}\n${stderr}`)
+        return;
       }
       resolve(stdout.trim())
     })
@@ -80,13 +73,9 @@ async function installSampleData(dir) {
       const installCommand = `composer require --ignore-platform-reqs "${packages.join('" "')}"`
       console.log(`Installing sample data packages`)
       childProcess.exec(installCommand, {maxBuffer: bufferBytes, cwd: dir}, (error, stdout, stderr) => {
-        if (stderr && stderr.includes('Generating autoload files')) stderr = '';
-        if (stderr) stderr = stderr.split('\n').filter(line => !line.startsWith('Deprecation Notice:')).join('\n').trim();
         if (error) {
-          reject(`Error executing command: ${error.message}`)
-        }
-        if (stderr) {
-          reject(`[error] ${stderr}`)
+          reject(`Error executing command: ${error.message}\n${stdout}\n${stderr}`)
+          return;
         }
         resolve(true)
       })
@@ -98,12 +87,9 @@ async function getInstalledPackageMap(dir) {
   const bufferBytes = 4 * 1024 * 1024; // 4M
   const output = await (new Promise((resolve, reject) => {
     childProcess.exec(command, {maxBuffer: bufferBytes, cwd: dir}, (error, stdout, stderr) => {
-      if (stderr) stderr = stderr.split('\n').filter(line => !line.startsWith('Deprecation Notice:')).join('\n').trim();
       if (error) {
-        reject(`Error executing command: ${error.message}`)
-      }
-      if (stderr) {
-        reject(`[error] ${stderr}`)
+        reject(`Error executing command: ${error.message}\n${stdout}\n${stderr}`)
+        return;
       }
       resolve(stdout)
     })
@@ -243,9 +229,11 @@ async function prepPackageForRelease(instruction, pkg, release, workingCopyPath)
 module.exports = {
   validateVersionString,
   updateComposerConfigFromMagentoToMageOs,
-  async getPackageVersionMap(releaseVersion) {
+  async getPackageVersionMap(releaseVersion, {skipSampleData = false} = {}) {
     const dir = await composerCreateMagentoProject(releaseVersion);
-    await installSampleData(dir);
+    if (!skipSampleData) {
+      await installSampleData(dir);
+    }
     return getInstalledPackageMap(dir);
   },
   /**

--- a/src/repository/shell-git.js
+++ b/src/repository/shell-git.js
@@ -98,11 +98,11 @@ async function exec(cmd, options) {
     const bufferBytes = 4 * 1024 * 1024; // 4M
     childProcess.exec(cmd, {maxBuffer: bufferBytes, ...(options || {})}, (error, stdout, stderr) => {
       if (error) {
-        reject(`Error executing command${options?.cwd ? ` in ${options.cwd}` : ''}: ${error.message}\n${stdout}`)
+        reject(`Error executing command${options?.cwd ? ` in ${options.cwd}` : ''}: ${error.message}\n${stdout}\n${stderr}`);
+        return;
       }
-      if (stderr) {
-        reject(`[error] ${stderr}`);
-      }
+      // git writes progress (e.g. "Updating files: 50%") and harmless warnings to stderr
+      // when stderr is a TTY. The exit code is the authoritative signal of failure.
       resolve(stdout);
     });
   });

--- a/tests/unit/release-branch-build-tools.test.js
+++ b/tests/unit/release-branch-build-tools.test.js
@@ -864,4 +864,90 @@ describe('release-branch-build-tools', () => {
       });
     });
   });
+
+  // ============================================================================
+  // determineLatestUpstreamMagentoRelease Tests
+  // ============================================================================
+  describe('determineLatestUpstreamMagentoRelease', () => {
+    let mockHttpSlurp;
+
+    beforeEach(() => {
+      jest.resetModules();
+      mockHttpSlurp = jest.fn();
+      jest.doMock('../../src/utils', () => ({
+        ...jest.requireActual('../../src/utils'),
+        httpSlurp: mockHttpSlurp,
+      }));
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+    });
+
+    const mockPayload = (versions) => JSON.stringify({
+      packages: {
+        'magento/product-community-edition': versions.map(v => ({version: v})),
+      },
+    });
+
+    it('picks the highest stable version', async () => {
+      mockHttpSlurp.mockResolvedValue(mockPayload(['2.4.6', '2.4.8', '2.4.7']));
+      const { determineLatestUpstreamMagentoRelease } = require('../../src/release-branch-build-tools');
+
+      const result = await determineLatestUpstreamMagentoRelease('https://mirror.example/');
+
+      expect(result).toBe('2.4.8');
+    });
+
+    it('treats -pN patch versions as stable and prefers them over the unpatched release', async () => {
+      mockHttpSlurp.mockResolvedValue(mockPayload(['2.4.7', '2.4.7-p1', '2.4.7-p3', '2.4.7-p2']));
+      const { determineLatestUpstreamMagentoRelease } = require('../../src/release-branch-build-tools');
+
+      const result = await determineLatestUpstreamMagentoRelease('https://mirror.example');
+
+      expect(result).toBe('2.4.7-p3');
+    });
+
+    it('filters out pre-release suffixes (alpha/beta/rc/dev)', async () => {
+      mockHttpSlurp.mockResolvedValue(mockPayload([
+        '2.4.7',
+        '2.4.8-alpha1',
+        '2.4.8-beta',
+        '2.4.8-rc1',
+        '2.4.8-dev',
+      ]));
+      const { determineLatestUpstreamMagentoRelease } = require('../../src/release-branch-build-tools');
+
+      const result = await determineLatestUpstreamMagentoRelease('https://mirror.example');
+
+      expect(result).toBe('2.4.7');
+    });
+
+    it('throws when no stable versions are available', async () => {
+      mockHttpSlurp.mockResolvedValue(mockPayload(['2.4.8-alpha1', '2.4.8-rc1']));
+      const { determineLatestUpstreamMagentoRelease } = require('../../src/release-branch-build-tools');
+
+      await expect(determineLatestUpstreamMagentoRelease('https://mirror.example'))
+        .rejects.toThrow(/No stable magento\/product-community-edition versions/);
+    });
+
+    it('throws a clear error when the payload is not valid JSON', async () => {
+      mockHttpSlurp.mockResolvedValue('<html>504 Gateway Timeout</html>');
+      const { determineLatestUpstreamMagentoRelease } = require('../../src/release-branch-build-tools');
+
+      await expect(determineLatestUpstreamMagentoRelease('https://mirror.example'))
+        .rejects.toThrow(/Could not parse package metadata/);
+    });
+
+    it('strips a trailing slash from the mirror URL', async () => {
+      mockHttpSlurp.mockResolvedValue(mockPayload(['2.4.8']));
+      const { determineLatestUpstreamMagentoRelease } = require('../../src/release-branch-build-tools');
+
+      await determineLatestUpstreamMagentoRelease('https://mirror.example/');
+
+      expect(mockHttpSlurp).toHaveBeenCalledWith(
+        'https://mirror.example/p2/magento/product-community-edition.json'
+      );
+    });
+  });
 });

--- a/tests/unit/repository/shell-git.test.js
+++ b/tests/unit/repository/shell-git.test.js
@@ -411,23 +411,22 @@ describe('shell-git', () => {
           .rejects.toMatch(/Error executing command.*Command failed/);
       });
 
-      it('should reject on stderr output', async () => {
+      it('should resolve when only stderr is present (git progress is not an error)', async () => {
         childProcess.exec.mockImplementation((cmd, options, callback) => {
-          callback(null, '', 'error message from stderr');
+          callback(null, 'ok', 'Updating files: 100% (38034/38034), done.');
         });
 
-        await expect(sut.testing.exec('command-with-stderr'))
-          .rejects.toBe('[error] error message from stderr');
+        await expect(sut.testing.exec('git checkout main')).resolves.toBe('ok');
       });
 
-      it('should include cwd in error message when provided', async () => {
+      it('should include cwd and stderr in error message when command fails', async () => {
         const mockError = new Error('Command failed');
         childProcess.exec.mockImplementation((cmd, options, callback) => {
-          callback(mockError, '', '');
+          callback(mockError, 'stdout context', 'stderr context');
         });
 
         await expect(sut.testing.exec('git status', { cwd: '/path/to/repo' }))
-          .rejects.toMatch(/Error executing command in \/path\/to\/repo/);
+          .rejects.toMatch(/Error executing command in \/path\/to\/repo.*stdout context.*stderr context/s);
       });
     });
   });


### PR DESCRIPTION
## Summary
- Fixes the integration-check failure on nightly builds where `element119/module-custom-admin-logo` and `elgentos/magento2-varnish-extended` could not be resolved, due to missing `replace` entries on `mage-os/*` packages.
- Auto-detects the latest stable upstream Magento Open Source release from `mirror.mage-os.org` and uses it as the source of `replace` versions, mirroring how the release build works.
- Fixes a pre-existing bug where benign git/composer stderr (e.g. `Updating files: 100%`) was treated as fatal — exposed when running the local test script with a TTY.

## Root cause
Third-party Magento extensions bundled into `product-community-edition` (`element119/module-custom-admin-logo`, `elgentos/magento2-varnish-extended`) require packages by their original `magento/*` names — e.g. `magento/framework *`, `magento/module-config ^101.0`, `magento/framework >=103.0.7`. Release builds satisfy that via `mage-os/framework`'s `replace: {"magento/framework": "103.0.9"}` entry, set by `updateComposerConfigFromMagentoToMageOs` (which only runs in the release path).

Nightly builds go through a different rename code path — `applyVendorRename` in `src/package-modules.js` — which renamed the package and dependencies but never wrote a `replace` entry. So the original `magento/*` names were unreachable from the nightly repo, and composer's resolver gave up.

The bug was latent for years; it only surfaced once bundled third-party extensions that depend on `magento/*` were added to the metapackage (around the Magento 3 alpha work). Earlier bundled extensions (`aligent/...`, `creatuity/...`, `swissup/...`, `n98/...`) declare no `magento/*` requires, so they were unaffected.

The `replace` version must be the **real upstream Magento component version** (e.g. `magento/framework 103.0.9`), not the nightly date version (`3.0.0.1-a20260524`). Constraints like `>=103.0.7` and `^101.0` would otherwise fail to match.

## What changed
| Change | File |
|---|---|
| Auto-detect latest upstream Magento on the mirror (`determineLatestUpstreamMagentoRelease`) | `src/release-branch-build-tools.js` |
| `skipSampleData` option for `getPackageVersionMap` | `src/release-build-tools.js` |
| **Write `replace` entry during the nightly rename** (the real fix) | `src/package-modules.js` (`applyVendorRename`) |
| Wire `replaceVersions` through the nightly buildState | `src/release-branch-build-tools.js`, `src/make/mageos-nightly.js` |
| `--upstreamRelease` CLI override on `mageos-nightly.js` | `src/make/mageos-nightly.js` |
| `try/catch` so nightly errors don't become `UnhandledPromiseRejection` | `src/make/mageos-nightly.js` |
| Trust exit code over stderr (composer & git progress is informational) | `src/repository/shell-git.js`, `src/release-build-tools.js` |

## Impact per build
- **mageos-nightly** — the fix applies here (the bug)
- **mageos-release** — stderr fix hardens the same latent risk; no other behavior change (`getPackageVersionMap` default preserved)
- **mirror** — stderr fix only; no other behavior change
- **upstream-nightly** — stderr fix only; the upstream-version fetch is isolated to `mageos-nightly.js` so this build does no extra work

## Test plan
- [x] All 821 existing unit tests pass
- [x] 6 new unit tests for `determineLatestUpstreamMagentoRelease` (highest stable, `-pN` precedence, pre-release filtering, no-stable error, invalid-JSON error, URL normalization)
- [x] Updated existing `shell-git.js exec()` test to assert the new contract: resolves on benign stderr, rejects with stdout+stderr context on real failure
- [x] `bash bin/test-nightly-local.sh mageos` end-to-end:
  - Built nightly packages locally
  - Verified `mage-os/framework` replace map: `{"magento/framework": "103.0.9"}`
  - Verified `mage-os/module-backend → 102.0.9`, `module-config → 101.2.9`, `module-store → 101.1.9`, `module-page-cache → 100.4.9`
  - `composer create-project mage-os/project-community-edition:@alpha` completed successfully with both `element119/module-custom-admin-logo` and `elgentos/magento2-varnish-extended` installed
- [ ] Confirm the next scheduled nightly run goes green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)