### PR TITLE
Make deploy SSH host configurable via REMOTE_HOST secret

### DIFF
--- a/.github/workflows/build-mageos-nightly.yml
+++ b/.github/workflows/build-mageos-nightly.yml
@@ -23,6 +23,7 @@ jobs:
     secrets:
       SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
       REMOTE_USER: ${{ secrets.REMOTE_USER }}
+      REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
   compute-nightly-service-versions:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/build-mageos-release.yml
+++ b/.github/workflows/build-mageos-release.yml
@@ -52,6 +52,7 @@ jobs:
     secrets:
       SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
       REMOTE_USER: ${{ secrets.REMOTE_USER }}
+      REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
   compute-release-service-versions:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/build-upstream-mirror.yml
+++ b/.github/workflows/build-upstream-mirror.yml
@@ -36,6 +36,7 @@ jobs:
     secrets:
       SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
       REMOTE_USER: ${{ secrets.REMOTE_USER }}
+      REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
 
   integrity-check:
     needs: [deploy]

--- a/.github/workflows/build-upstream-nightly.yml
+++ b/.github/workflows/build-upstream-nightly.yml
@@ -23,6 +23,7 @@ jobs:
     secrets:
       SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
       REMOTE_USER: ${{ secrets.REMOTE_USER }}
+      REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
   compute-nightly-service-versions:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,9 @@ on:
       REMOTE_USER:
         description: "The system user used to upload to the satis server."
         required: true
+      REMOTE_HOST:
+        description: "Override the SSH host used for deployment. Set this to the origin IP or an unproxied/DNS-only hostname when repo.mage-os.org is behind the Cloudflare proxy (SSH/port 22 is not proxied). Falls back to repo.mage-os.org when unset."
+        required: false
 
 env:
   remote_host: "repo.mage-os.org"
@@ -107,7 +110,7 @@ jobs:
         name: "Rsync over SSH"
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SERVER_SSH_KEY }}
-          REMOTE_HOST: ${{ env.remote_host }}
+          REMOTE_HOST: ${{ secrets.REMOTE_HOST || env.remote_host }}
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           TARGET: ${{ env.remote_dir }}
           ARGS: "--verbose --compress --recursive --links --times --omit-dir-times ${{ env.delete_arg }}"


### PR DESCRIPTION
## Problem

The deploy workflow (`deploy.yml`) rsyncs the generated composer repo over **SSH** to a hardcoded host, `repo.mage-os.org` (`env.remote_host`, used by the `easingthemes/ssh-deploy` step). All four build entrypoints route through it: mirror, release, Mage-OS nightly, and upstream nightly.

Now that `repo.mage-os.org` is served through the **Cloudflare proxy** (orange-cloud), only HTTP/HTTPS is proxied. SSH (port 22) is terminated at Cloudflare's edge and never reaches the origin, so the deploy step can't connect — this is the mirror build failure Ryan flagged.

## Fix

Make the SSH host overridable via a new **optional** `REMOTE_HOST` secret:

- `deploy.yml`: declares the optional secret and uses `REMOTE_HOST: ${{ secrets.REMOTE_HOST || env.remote_host }}` — falls back to `repo.mage-os.org` when the secret is unset, so **behavior is unchanged until the secret is created**.
- Threaded the secret through all four callers (`build-upstream-mirror`, `build-mageos-release`, `build-mageos-nightly`, `build-upstream-nightly`), which all deploy to the same host.

No committed IPs/hostnames; the value stays in repo secrets.

## ⚠️ Required follow-up (maintainer/admin action)

This PR only makes the host configurable. **The deploys stay broken until someone with repo/org admin sets the `REMOTE_HOST` secret** to a target that bypasses Cloudflare:

- the satis server's **origin IP**, or
- an **unproxied / DNS-only hostname** (grey-cloud record pointing at the origin) — preferred, survives IP changes.

Once the secret is set, the next mirror/nightly/release deploy will SSH to that host instead.