### PR TITLE
Add Marcel Martinez as an allowed deployer

### DIFF
--- a/.github/workflows/build-mageos-release.yml
+++ b/.github/workflows/build-mageos-release.yml
@@ -39,7 +39,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml
     name: "generate & deploy"
-    if: contains('["vinai", "rhoerr", "fballiano", "mage-os-ci"]', github.actor)
+    if: contains('["vinai", "rhoerr", "marcelmtz", "mage-os-ci"]', github.actor)
     with:
       repo: ${{ inputs.repo }}
       remote_dir: ${{ inputs.remote_dir }}

--- a/.github/workflows/build-upstream-mirror.yml
+++ b/.github/workflows/build-upstream-mirror.yml
@@ -27,7 +27,7 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml
     name: "generate & deploy"
-    if: contains('["vinai", "rhoerr", "fballiano", "mage-os-ci"]', github.actor)
+    if: contains('["vinai", "rhoerr", "marcelmtz", "mage-os-ci"]', github.actor)
     with:
       repo: ${{ (github.event_name == 'workflow_dispatch' && inputs.repo) || 'https://preview-mirror.mage-os.org/' }}
       remote_dir: ${{ (github.event_name == 'workflow_dispatch' && inputs.remote_dir) || '/var/www/preview-mirror.mage-os.org/html/' }}


### PR DESCRIPTION
This changes our mirror and distribution release workflows to allow our current release manager (@marcelmtz) to cut releases. Also removes fballiano who's no longer involved.