### PR TITLE
Fix non-reproducible base packages caused by environment-dependent file modes

### DIFF
--- a/src/repository/shell-git.js
+++ b/src/repository/shell-git.js
@@ -190,6 +190,43 @@ async function listFileNames(repoDir, path, excludes) {
 
 }
 
+/**
+ * Return the set of repo-root-relative paths that git records as executable (tree mode 100755).
+ *
+ * The executable bit must come from git's committed tree mode, not from fs.statSync() on the
+ * checked-out file: the working-tree mode depends on the checkout environment (core.fileMode,
+ * umask, filesystem) and varies between machines, which makes the generated package zip
+ * non-reproducible and can silently drop the exec bit (e.g. bin/magento). `git ls-tree` reads
+ * the tree object directly and is environment-independent. Paths are scoped to pathInRepo and
+ * returned relative to the repo root, matching listFileNames() output.
+ *
+ * @param {String} repoDir
+ * @param {String} pathInRepo
+ * @returns {Promise<Set<String>>}
+ */
+async function listExecutablePaths(repoDir, pathInRepo) {
+  // -z: NUL-terminated records with no path quoting, so paths match listFileNames() byte-for-byte.
+  // Raise maxBuffer because a full-repo listing (e.g. magento2-base) can exceed the 4M default.
+  // Use execFile with an argv array (no shell) and pass pathInRepo after the `--` separator so it
+  // can never be parsed as a git option or interpreted by a shell, even though it originates from
+  // trusted build config rather than user input.
+  const args = ['ls-tree', '-r', '-z', 'HEAD'];
+  if (pathInRepo) args.push('--', pathInRepo);
+  const out = await new Promise((resolve, reject) => {
+    childProcess.execFile('git', args, {cwd: repoDir, maxBuffer: 256 * 1024 * 1024}, (error, stdout, stderr) => {
+      error ? reject(`Error executing git ls-tree in ${repoDir}: ${error.message}\n${stderr}`) : resolve(stdout);
+    });
+  });
+  const executable = new Set();
+  for (const entry of out.split("\0")) {
+    // Each record is "<mode> <type> <sha>\t<path>"; only 100755 blobs are executable.
+    if (entry.slice(0, 7) === '100755 ') {
+      executable.add(entry.slice(entry.indexOf("\t") + 1));
+    }
+  }
+  return executable;
+}
+
 async function createBranch(url, branch, ref) {
   const dir = fullRepoPath(url);
 
@@ -222,12 +259,13 @@ module.exports = {
     if (! fs.existsSync(path.join(dir, pathInRepo))) return [];
     const excludeStrings = excludes.map(exclude => typeof exclude === 'function' ? exclude(ref) : exclude).filter(exclude => exclude.length > 0);
     const fileNames = await listFileNames(dir, pathInRepo, excludeStrings || []);
+    const executablePaths = await listExecutablePaths(dir, pathInRepo);
     return fileNames.map(filepath => {
       const fullPath = path.join(dir, filepath);
       return {
         filepath,
         contentBuffer: fs.readFileSync(fullPath),
-        isExecutable: 0o100755 === fs.statSync(fullPath).mode
+        isExecutable: executablePaths.has(filepath)
       }
     });
   },

--- a/tests/unit/repository/shell-git.test.js
+++ b/tests/unit/repository/shell-git.test.js
@@ -750,6 +750,10 @@ describe('shell-git', () => {
       fs.readFileSync.mockReset();
       fs.statSync.mockReset();
       childProcess.exec.mockReset();
+      childProcess.execFile.mockReset();
+      // listFiles reads the executable bit from `git ls-tree` (via execFile); default to
+      // "no executable files". Tests that need executables override this per-case.
+      childProcess.execFile.mockImplementation((file, args, options, callback) => callback(null, '', ''));
     });
 
     describe('happy path', () => {
@@ -781,7 +785,6 @@ describe('shell-git', () => {
       it('should mark executable files correctly', async () => {
         fs.existsSync.mockReturnValue(true);
         fs.readFileSync.mockReturnValue(Buffer.from('#!/bin/bash'));
-        fs.statSync.mockReturnValue({ mode: 0o100755 });
 
         childProcess.exec.mockImplementation((cmd, options, callback) => {
           if (cmd.includes('git describe')) {
@@ -795,9 +798,47 @@ describe('shell-git', () => {
           }
         });
 
+        // The executable bit comes from git's recorded tree mode (100755), not the
+        // checked-out file's filesystem mode.
+        childProcess.execFile.mockImplementation((file, args, options, callback) =>
+          callback(null, '100755 blob 0000000000000000000000000000000000000000\tbin/script.sh\0', ''));
+
         const result = await sut.listFiles('https://github.com/mage-os/test-repo.git', 'bin', 'main', []);
 
         expect(result[0].isExecutable).toBe(true);
+      });
+
+      it('should source the executable bit from git tree mode, not the filesystem mode', async () => {
+        // Regression: the checked-out file's fs mode is environment-dependent (core.fileMode,
+        // umask, filesystem) and must NOT drive the exec bit. Here the on-disk file reports
+        // 0644 but git records it as 100755 -> it must be marked executable, so rebuilt zips
+        // stay byte-reproducible with the published packages (e.g. bin/magento).
+        fs.existsSync.mockReturnValue(true);
+        fs.readFileSync.mockReturnValue(Buffer.from('#!/usr/bin/env php'));
+        fs.statSync.mockReturnValue({ mode: 0o100644 });
+
+        childProcess.exec.mockImplementation((cmd, options, callback) => {
+          if (cmd.includes('git describe') || cmd.includes('git branch --show-current')) {
+            callback(null, 'main\n', '');
+          } else if (cmd.includes('find')) {
+            callback(null, 'bin/magento\n', '');
+          } else {
+            callback(null, '', '');
+          }
+        });
+        childProcess.execFile.mockImplementation((file, args, options, callback) =>
+          callback(null, '100755 blob 0000000000000000000000000000000000000000\tbin/magento\0', ''));
+
+        const result = await sut.listFiles('https://github.com/mage-os/test-repo.git', 'bin', 'main', []);
+
+        expect(result[0].isExecutable).toBe(true);
+        // git must be invoked without a shell (execFile), with pathInRepo after the `--` separator.
+        expect(childProcess.execFile).toHaveBeenCalledWith(
+          'git',
+          expect.arrayContaining(['ls-tree', '-r', '-z', 'HEAD', '--', 'bin']),
+          expect.any(Object),
+          expect.any(Function)
+        );
       });
 
       it('should validate ref security', async () => {


### PR DESCRIPTION
## Problem

Generated base packages (e.g. `mage-os/magento2-base`) are not byte-reproducible across build environments, which causes their dist checksums to change when a package is rebuilt and re-published in place. When that happens, `composer install` fails dist checksum verification for anyone whose `composer.lock` (or a caching mirror) still references the previously published archive.

The root cause is in `listFiles()` in `src/repository/shell-git.js`, which derived each file's executable bit from the **checked-out working-tree mode**:

```js
isExecutable: 0o100755 === fs.statSync(fullPath).mode
```

`fs.statSync().mode` reflects whatever the checkout left on disk, which depends on the build environment — `git core.fileMode`, the umask, and the filesystem. The same tag therefore produces different zip-entry permission bits on different machines. Because the archive stores those permissions, identical file *content* yields a different archive and a different checksum.

Two concrete symptoms:

- **Checksum churn.** A rebuild-in-place re-publishes byte-different archives (same content, flipped permission bits), breaking existing lockfiles.
- **Broken executables.** In an environment that doesn't preserve the exec bit, files such as `bin/magento` are packaged as `0644`, so the Magento CLI is not executable after install.

The exact-equality check (`=== 0o100755`) is also fragile — it silently treats `0775`, `0700`, etc. as non-executable.

## Solution

Source the executable bit from git's **committed tree mode** (`100755`) instead of the working-tree filesystem mode. Git records each blob's mode in the tree object independently of the checkout environment, so it is deterministic:

```js
const executablePaths = await listExecutablePaths(dir, pathInRepo); // git ls-tree -r -z HEAD
// ...
isExecutable: executablePaths.has(filepath)
```

`git ls-tree` is invoked with `execFile` (no shell) and `pathInRepo` is passed after the `--` separator so it can never be parsed as a git option — this also resolves a command-injection warning from static analysis. The `-z` flag disables path quoting so entries match the file list byte-for-byte.

This fixes both reproducibility and correctness: git records `bin/magento` as `100755`, so every build emits `0755` regardless of environment.

## Verification

- Rebuilt **every published `mage-os/magento2-base` version (1.0.0 through 3.0.0)** and confirmed each is **byte-identical** to the artifact currently published on `repo.mage-os.org` (matching dist shasums).
- Added a regression test asserting the executable bit follows git's tree mode rather than the filesystem mode, and that git is invoked without a shell. Full `shell-git` unit suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)