### PR TITLE
Make mirror builds manual-only, fix integrity diff noise, add workflow concurrency groups

### DIFF
--- a/.github/workflows/build-mageos-nightly.yml
+++ b/.github/workflows/build-mageos-nightly.yml
@@ -11,6 +11,11 @@ on:
         required: false
         default: ''
 
+# Queue rather than cancel so an in-progress deploy is never interrupted
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/build-mageos-release.yml
+++ b/.github/workflows/build-mageos-release.yml
@@ -35,6 +35,12 @@ on:
         default: false
         type: boolean
 
+# One release build per target repo at a time; never auto-cancel a release
+# mid-deploy or mid-tag-push
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.repo }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/build-upstream-mirror.yml
+++ b/.github/workflows/build-upstream-mirror.yml
@@ -20,6 +20,12 @@ on:
           - /var/www/preview-mirror.mage-os.org/html/
           - /var/www/mirror.mage-os.org/html/
 
+# One build per deploy target at a time; queue rather than cancel so an
+# in-progress rsync is never interrupted mid-deploy
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.remote_dir }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/build-upstream-mirror.yml
+++ b/.github/workflows/build-upstream-mirror.yml
@@ -19,9 +19,6 @@ on:
         options:
           - /var/www/preview-mirror.mage-os.org/html/
           - /var/www/mirror.mage-os.org/html/
-  push:
-    branches:
-      - main
 
 jobs:
   deploy:

--- a/.github/workflows/build-upstream-nightly.yml
+++ b/.github/workflows/build-upstream-nightly.yml
@@ -11,6 +11,11 @@ on:
         required: false
         default: ''
 
+# Queue rather than cancel so an in-progress deploy is never interrupted
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/download-missing-packages.yml
+++ b/.github/workflows/download-missing-packages.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+# Concurrent runs would conflict on the update-packages PR branch; queue instead
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   download-packages:
     runs-on: ubuntu-latest

--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -59,7 +59,8 @@ jobs:
       - run: node src/integrity-test/validate-package-versions-match.js ${{ github.workspace }}/mageos/vendor ${{ github.workspace }}/magento/vendor
         name: Package Versions Validate
 
-      # Ignore composer.json, composer.log, generated composer autoload files and files in var/cache that start with `mage---`
-      - run: diff -rq -x "*composer*" -x "*autoload*" -x "*mage---*" -x "debug.log" -x ".git" ${{ github.workspace }}/magento ${{ github.workspace }}/mageos
+      # Ignore composer.json, composer.log, generated composer autoload files and files in var/cache that start with `mage---`,
+      # plus the var/cache and var/page_cache runtime dirs, whose hashed cache-ID subdirectories differ per install path
+      - run: diff -rq -x "*composer*" -x "*autoload*" -x "*mage---*" -x "cache" -x "page_cache" -x "debug.log" -x ".git" ${{ github.workspace }}/magento ${{ github.workspace }}/mageos
         if: always()
         name: Files Integrity Check

--- a/.github/workflows/sansec-ecomscan.yml
+++ b/.github/workflows/sansec-ecomscan.yml
@@ -5,6 +5,11 @@ on:
   pull_request_target:
   workflow_dispatch:
 
+# Only the latest scan per PR/branch matters; cancel superseded runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-ecomscan:
     # Skip if it's a push event on a PR (it can't access secrets)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded PR test runs; queue (never cancel) runs for pushes to main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Three related CI hygiene changes:

1. **Mirror builds are now manual-only.** The `push: branches: [main]` trigger is removed from `build-upstream-mirror.yml`. Every push to main was kicking off a full multi-hour mirror build and preview-mirror deploy regardless of whether the change could affect mirror output (e.g. deployer allowlist or docs changes) — and in practice those auto-runs were being manually cancelled and replaced with a `workflow_dispatch` anyway (see the cancel+dispatch pairs on May 31, Jun 3, Jul 7, Jul 11). Mirror builds now run only via `workflow_dispatch`. Note this means preview-mirror is no longer refreshed automatically after merging package PRs (e.g. from the download-missing-packages workflow); dispatch a mirror build after merging those.

2. **Integrity check: exclude runtime cache dirs from the files diff.** `var/cache` and `var/page_cache` contain hashed cache-ID subdirectories derived from the install path (`485_` vs `680_`), so they always differ between the magento and mageos installs and fail the check spuriously — this is what failed 2.4.9 in recent runs.

3. **Concurrency groups for all trigger-owning workflows.** Fixes #278. Policy varies by workflow, commented inline:
   - Deploying workflows (mirror, nightlies, release, download-missing-packages) queue with `cancel-in-progress: false`, keyed per deploy target where applicable (`inputs.remote_dir` / `inputs.repo`), so an in-progress rsync deploy or release tag push is never interrupted. GitHub keeps at most one pending run per group, so bursts still collapse to "current run + newest queued run".
   - Tests cancel superseded runs on PRs but queue on pushes to main, so every main commit retains a completed test run.
   - eComscan cancels superseded scans, grouped per PR/branch.

   The reusable workflows (`deploy.yml`, `integrity-check.yml`, `push-release-tag.yml`) intentionally get no concurrency block — workflow-level `concurrency` is ignored under `workflow_call`; the callers' groups cover them.

## Not fixed here

The other recurring integrity failure (2.4.7: Composer ≥2.9 refuses to install advisory-flagged historical versions, e.g. PKSA-db8d-773v-rd1n) needs an `audit.block-insecure: false` change in the `checkout-magento` action — follow-up material.

## Testing

- All 10 workflow files parse-validated with js-yaml.
- Behavior changes are trigger/concurrency config only; no build logic touched.

Fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)