### PR TITLE
Await archive write completion in package generation

### DIFF
--- a/src/mirror-build-tools.js
+++ b/src/mirror-build-tools.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const {pipeline} = require('stream/promises');
 const repo = require('./repository');
 const {isVersionGreaterOrEqual} = require('./utils');
 const zip = require('jszip');
@@ -174,23 +175,22 @@ async function replacePackageFiles(pkg) {
     throw {message: `Could not find archive ${packageFilePath} for replacement: ${pkg.name}:${pkg.version}.`};
   }
 
-  fs.readFile(packageFilePath, function(_, data) {
-    zip.loadAsync(data).then(function(contents) {
-      pkg.files.forEach(function(file) {
-        const replacementFilePath = `${__dirname}/../resource/replace/${pkg.name}/${pkg.version}/${file}`;
-        if (!fs.existsSync(replacementFilePath)) {
-          throw {message: `Replacement file does not exist: ${replacementFilePath}`}
-        }
-        contents.file(
-          file,
-          fs.readFileSync(replacementFilePath),
-          {date: new Date('2022-02-22 22:02:22.000Z'), unixPermissions: '644'}
-        );
-      })
-      const stream = contents.generateNodeStream({streamFiles: false, platform: 'UNIX'});
-      stream.pipe(fs.createWriteStream(packageFilePath));
-    })
-  });
+  const contents = await zip.loadAsync(await fs.promises.readFile(packageFilePath));
+
+  for (const file of pkg.files) {
+    const replacementFilePath = `${__dirname}/../resource/replace/${pkg.name}/${pkg.version}/${file}`;
+    if (!fs.existsSync(replacementFilePath)) {
+      throw {message: `Replacement file does not exist: ${replacementFilePath}`};
+    }
+    contents.file(
+      file,
+      fs.readFileSync(replacementFilePath),
+      {date: new Date('2022-02-22 22:02:22.000Z'), unixPermissions: '644'}
+    );
+  }
+
+  const stream = contents.generateNodeStream({streamFiles: false, platform: 'UNIX'});
+  await pipeline(stream, fs.createWriteStream(packageFilePath));
 }
 
 /**

--- a/src/package-modules.js
+++ b/src/package-modules.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const {pipeline} = require('stream/promises');
 const {determineSourceDependencies} = require('./determine-dependencies');
 const JSZip = require('jszip');
 const repo = require("./repository");
@@ -79,7 +80,7 @@ async function writePackage(packageFilepath, files) {
   ensureArchiveDirectoryExists(packageFilepath);
   const zip = zipFileWith(files);
   const stream = await zip.generateNodeStream({streamFiles: false, platform: 'UNIX'});
-  stream.pipe(fs.createWriteStream(packageFilepath));
+  await pipeline(stream, fs.createWriteStream(packageFilepath));
 }
 
 /**

--- a/tests/unit/mirror-build-tools.test.js
+++ b/tests/unit/mirror-build-tools.test.js
@@ -784,6 +784,32 @@ describe('mirror-build-tools', () => {
         .rejects.toEqual({ message: expect.stringContaining('Could not find archive') });
     });
 
+    test('should throw if replacement file does not exist', async () => {
+      archiveFilePath.mockReturnValue('/test/archive/vendor-pkg-1.0.0.zip');
+      fs.existsSync.mockReset();
+      fs.existsSync.mockImplementation((p) => p === '/test/archive/vendor-pkg-1.0.0.zip');
+
+      const instruction = {
+        repoUrl: 'https://github.com/test/repo.git',
+        fromTag: '1.0.0',
+        vendor: 'test',
+        extraRefToRelease: [],
+        packageDirs: [],
+        packageIndividual: [],
+        packageMetaFromDirs: [],
+        packageReplacements: [
+          { name: 'vendor/pkg', version: '1.0.0', files: ['file.txt'] }
+        ],
+        extraMetapackages: [],
+        skipTags: {},
+        fixVersions: {},
+        transform: {}
+      };
+
+      await expect(sut.processMirrorInstruction(instruction, { composerRepoUrl: 'https://repo.test' }))
+        .rejects.toEqual({ message: expect.stringContaining('Replacement file does not exist') });
+    });
+
     test('should read existing package archive', async () => {
       // Completely reset existsSync and set up fresh implementation
       fs.existsSync.mockReset();

--- a/tests/unit/mirror-build-tools.test.js
+++ b/tests/unit/mirror-build-tools.test.js
@@ -2,6 +2,7 @@
 
 const sut = require('../../src/mirror-build-tools');
 const fs = require('fs');
+const {PassThrough} = require('stream');
 const repo = require('../../src/repository');
 const { isVersionGreaterOrEqual } = require('../../src/utils');
 const {
@@ -34,7 +35,8 @@ describe('mirror-build-tools', () => {
     fs.copyFile.mockImplementation((_, __, cb) => cb(null));
     fs.readFile.mockImplementation((_, cb) => cb(null, Buffer.from('test')));
     fs.readFileSync.mockReturnValue(Buffer.from('test'));
-    fs.createWriteStream.mockReturnValue({ on: jest.fn() });
+    fs.createWriteStream.mockImplementation(() => new PassThrough());
+    fs.promises = { readFile: jest.fn().mockResolvedValue(Buffer.from('test')) };
 
     // Default mocks for repository
     repo.listTags.mockResolvedValue(['1.0.0', '2.0.0', '2.1.0']);
@@ -59,8 +61,10 @@ describe('mirror-build-tools', () => {
     // Mock JSZip - loadAsync returns a promise that resolves to the zip contents
     const mockZipContents = {
       file: jest.fn(),
-      generateNodeStream: jest.fn().mockReturnValue({
-        pipe: jest.fn()
+      generateNodeStream: jest.fn().mockImplementation(() => {
+        const stream = new PassThrough();
+        stream.end();
+        return stream;
       })
     };
     JSZip.loadAsync = jest.fn().mockResolvedValue(mockZipContents);
@@ -351,22 +355,12 @@ describe('mirror-build-tools', () => {
 
       // Mock for replacePackageFiles
       fs.existsSync.mockReturnValue(true);
-      fs.readFile.mockImplementation((filepath, cb) => {
-        cb(null, Buffer.from('PK' + '\x00'.repeat(100))); // Mock ZIP file
-      });
-
-      const mockZip = {
-        file: jest.fn(),
-        generateNodeStream: jest.fn().mockReturnValue({ pipe: jest.fn() })
-      };
-
-      // Since replacePackageFiles uses callback pattern, we need to mock appropriately
-      // The actual call happens through zip.loadAsync which we've mocked above
+      fs.promises.readFile.mockResolvedValue(Buffer.from('PK' + '\x00'.repeat(100))); // Mock ZIP file
 
       await sut.processMirrorInstruction(instruction, releaseContext);
 
-      // Verify readFile was called for package replacements
-      expect(fs.readFile).toHaveBeenCalled();
+      // Verify the archive was read for package replacements
+      expect(fs.promises.readFile).toHaveBeenCalled();
     });
 
     test('should process all extraMetapackages', async () => {
@@ -797,15 +791,17 @@ describe('mirror-build-tools', () => {
 
       archiveFilePath.mockReturnValue('/test/archive/vendor-pkg-1.0.0.zip');
 
-      fs.readFile.mockImplementation((_, cb) => cb(null, Buffer.from('test')));
       fs.readFileSync.mockReturnValue(Buffer.from('test'));
-      fs.createWriteStream.mockReturnValue({ on: jest.fn() });
+      fs.createWriteStream.mockImplementation(() => new PassThrough());
+      fs.promises.readFile.mockResolvedValue(Buffer.from('test'));
 
       // Mock JSZip load and file operations
       const mockContents = {
         file: jest.fn().mockReturnThis(),
-        generateNodeStream: jest.fn().mockReturnValue({
-          pipe: jest.fn()
+        generateNodeStream: jest.fn().mockImplementation(() => {
+          const stream = new PassThrough();
+          stream.end();
+          return stream;
         })
       };
       JSZip.loadAsync = jest.fn().mockResolvedValue(mockContents);
@@ -829,10 +825,7 @@ describe('mirror-build-tools', () => {
 
       await sut.processMirrorInstruction(instruction, { composerRepoUrl: 'https://repo.test' });
 
-      expect(fs.readFile).toHaveBeenCalledWith(
-        '/test/archive/vendor-pkg-1.0.0.zip',
-        expect.any(Function)
-      );
+      expect(fs.promises.readFile).toHaveBeenCalledWith('/test/archive/vendor-pkg-1.0.0.zip');
     });
   });
 

--- a/tests/unit/package-modules-write.test.js
+++ b/tests/unit/package-modules-write.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {writePackage} = require('../../src/package-modules');
+
+describe('writePackage', () => {
+  test('resolves only after the archive is fully written to disk', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-write-'));
+    const target = path.join(dir, 'out.zip');
+    await writePackage(target, [{
+      filepath: 'composer.json',
+      contentBuffer: Buffer.from('{"name":"a/b"}', 'utf8'),
+      mtime: new Date('2022-02-22 22:02:22.000Z'),
+      isExecutable: false,
+    }]);
+    expect(fs.existsSync(target)).toBe(true);
+    expect(fs.statSync(target).size).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/package-modules-write.test.js
+++ b/tests/unit/package-modules-write.test.js
@@ -4,8 +4,14 @@ const path = require('path');
 const {writePackage} = require('../../src/package-modules');
 
 describe('writePackage', () => {
+  let dir;
+
+  afterAll(() => {
+    fs.rmSync(dir, {recursive: true, force: true});
+  });
+
   test('resolves only after the archive is fully written to disk', async () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-write-'));
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-write-'));
     const target = path.join(dir, 'out.zip');
     await writePackage(target, [{
       filepath: 'composer.json',

--- a/tests/unit/package-modules.test.js
+++ b/tests/unit/package-modules.test.js
@@ -798,7 +798,6 @@ describe('determineMetaPackageFromRepoDir', () => {
 
 describe('createPackageForRef', () => {
   let mockZip;
-  let mockStream;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -1076,7 +1075,6 @@ describe('createPackagesForRef', () => {
 
 describe('createMetaPackageFromRepoDir', () => {
   let mockZip;
-  let mockStream;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -1169,7 +1167,6 @@ describe('createMetaPackageFromRepoDir', () => {
 
 describe('createMetaPackage', () => {
   let mockZip;
-  let mockStream;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -1263,7 +1260,6 @@ describe('createMetaPackage', () => {
 
 describe('createComposerJsonOnlyPackage', () => {
   let mockZip;
-  let mockStream;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -1490,7 +1486,6 @@ describe('determinePackagesForRef', () => {
 
 describe('ZIP creation behavior', () => {
   let mockZip;
-  let mockStream;
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/tests/unit/package-modules.test.js
+++ b/tests/unit/package-modules.test.js
@@ -20,6 +20,13 @@
  */
 
 const path = require('path');
+const {PassThrough} = require('stream');
+
+function endedStream() {
+  const stream = new PassThrough();
+  stream.end();
+  return stream;
+}
 
 // Mock dependencies before requiring the module under test
 jest.mock('fs');
@@ -797,19 +804,16 @@ describe('createPackageForRef', () => {
     jest.clearAllMocks();
 
     // Setup JSZip mock
-    mockStream = {
-      pipe: jest.fn(),
-    };
     mockZip = {
       file: jest.fn(),
-      generateNodeStream: jest.fn().mockResolvedValue(mockStream),
+      generateNodeStream: jest.fn().mockImplementation(endedStream),
     };
     JSZip.mockImplementation(() => mockZip);
 
     // Setup fs mocks
     fs.existsSync.mockReturnValue(false);
     fs.mkdirSync.mockImplementation(() => {});
-    fs.createWriteStream.mockReturnValue({});
+    fs.createWriteStream.mockImplementation(() => new PassThrough());
 
     // Setup repo mocks
     repo.listFiles.mockResolvedValue([
@@ -979,17 +983,16 @@ describe('createPackagesForRef', () => {
     jest.clearAllMocks();
 
     // Setup JSZip mock
-    const mockStream = { pipe: jest.fn() };
     const mockZip = {
       file: jest.fn(),
-      generateNodeStream: jest.fn().mockResolvedValue(mockStream),
+      generateNodeStream: jest.fn().mockImplementation(endedStream),
     };
     JSZip.mockImplementation(() => mockZip);
 
     // Setup fs mocks
     fs.existsSync.mockReturnValue(false);
     fs.mkdirSync.mockImplementation(() => {});
-    fs.createWriteStream.mockReturnValue({});
+    fs.createWriteStream.mockImplementation(() => new PassThrough());
 
     // Reset archive base dir
     sut.setArchiveBaseDir('packages');
@@ -1079,17 +1082,16 @@ describe('createMetaPackageFromRepoDir', () => {
     jest.clearAllMocks();
 
     // Setup JSZip mock
-    mockStream = { pipe: jest.fn() };
     mockZip = {
       file: jest.fn(),
-      generateNodeStream: jest.fn().mockResolvedValue(mockStream),
+      generateNodeStream: jest.fn().mockImplementation(endedStream),
     };
     JSZip.mockImplementation(() => mockZip);
 
     // Setup fs mocks
     fs.existsSync.mockReturnValue(false);
     fs.mkdirSync.mockImplementation(() => {});
-    fs.createWriteStream.mockReturnValue({});
+    fs.createWriteStream.mockImplementation(() => new PassThrough());
 
     // Reset archive base dir
     sut.setArchiveBaseDir('packages');
@@ -1173,17 +1175,16 @@ describe('createMetaPackage', () => {
     jest.clearAllMocks();
 
     // Setup JSZip mock
-    mockStream = { pipe: jest.fn() };
     mockZip = {
       file: jest.fn(),
-      generateNodeStream: jest.fn().mockResolvedValue(mockStream),
+      generateNodeStream: jest.fn().mockImplementation(endedStream),
     };
     JSZip.mockImplementation(() => mockZip);
 
     // Setup fs mocks
     fs.existsSync.mockReturnValue(false);
     fs.mkdirSync.mockImplementation(() => {});
-    fs.createWriteStream.mockReturnValue({});
+    fs.createWriteStream.mockImplementation(() => new PassThrough());
 
     // Reset archive base dir
     sut.setArchiveBaseDir('packages');
@@ -1268,17 +1269,16 @@ describe('createComposerJsonOnlyPackage', () => {
     jest.clearAllMocks();
 
     // Setup JSZip mock
-    mockStream = { pipe: jest.fn() };
     mockZip = {
       file: jest.fn(),
-      generateNodeStream: jest.fn().mockResolvedValue(mockStream),
+      generateNodeStream: jest.fn().mockImplementation(endedStream),
     };
     JSZip.mockImplementation(() => mockZip);
 
     // Setup fs mocks
     fs.existsSync.mockReturnValue(false);
     fs.mkdirSync.mockImplementation(() => {});
-    fs.createWriteStream.mockReturnValue({});
+    fs.createWriteStream.mockImplementation(() => new PassThrough());
     fs.readFileSync.mockReturnValue(Buffer.from('# .gitignore'));
 
     // Reset archive base dir
@@ -1496,17 +1496,16 @@ describe('ZIP creation behavior', () => {
     jest.clearAllMocks();
 
     // Setup JSZip mock
-    mockStream = { pipe: jest.fn() };
     mockZip = {
       file: jest.fn(),
-      generateNodeStream: jest.fn().mockResolvedValue(mockStream),
+      generateNodeStream: jest.fn().mockImplementation(endedStream),
     };
     JSZip.mockImplementation(() => mockZip);
 
     // Setup fs mocks
     fs.existsSync.mockReturnValue(false);
     fs.mkdirSync.mockImplementation(() => {});
-    fs.createWriteStream.mockReturnValue({});
+    fs.createWriteStream.mockImplementation(() => new PassThrough());
 
     // Setup repo mocks
     repo.listFiles.mockResolvedValue([


### PR DESCRIPTION
## Summary

Two latent races in the checksum-critical write path let the build report success before bytes were on disk, and swallowed errors:

- `writePackage` piped the zip stream to a write stream without awaiting completion, so callers resolved while the archive was still being written.
- `replacePackageFiles` used a callback `fs.readFile` that its caller's `await` never waited on — a throw inside the promise chain surfaced as an unhandled rejection instead of failing the build.

Both now use `stream/promises` `pipeline` and `fs.promises.readFile`, so completion is genuinely awaited and errors propagate.

## Architecture / compatibility

No interface changes: `writePackage` and `replacePackageFiles` were already treated as async by every caller — they just didn't keep the promise contract. Test mocks that only worked because the old code never awaited the write were updated to behave like real streams.

## Testing

- New `tests/unit/package-modules-write.test.js` asserting `writePackage` resolves only after the archive is fully on disk.
- New rejection test for the "Replacement file does not exist" guard in `replacePackageFiles`, which previously had no coverage.
- Full suite: 870 tests, 0 failures.

Split out of the #325 investigation (see companion PRs); this fix is independent of the replace-order work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)