### PR TITLE
Allow installing advisory-affected versions in integrity checks

### DIFF
--- a/.github/actions/checkout-magento/action.yml
+++ b/.github/actions/checkout-magento/action.yml
@@ -81,6 +81,24 @@ runs:
       working-directory: ${{ inputs.install-directory }}
       if: ${{ !startsWith(inputs.composer-version, '1') }}
 
+    # Composer 2.9+ blocks advisory-affected versions in the solver, not just in the
+    # audit report, so a release that is known-vulnerable becomes uninstallable. This
+    # harness has to reproduce Adobe's dependency tree verbatim to diff against it, and
+    # older releases are legitimately affected by advisories, so the block is disabled
+    # here. The key was renamed to policy.advisories.block in 2.10; audit.block-insecure
+    # is the pre-2.10 spelling, and neither exists on 1.x/2.2.x, hence the fallbacks.
+    - name: Allow installing advisory-affected versions
+      run: |
+        if composer config --no-interaction policy.advisories.block false 2>/dev/null; then
+          echo "Advisory blocking disabled via policy.advisories.block"
+        elif composer config --no-interaction audit.block-insecure false 2>/dev/null; then
+          echo "Advisory blocking disabled via audit.block-insecure"
+        else
+          echo "Composer ${{ inputs.composer-version }} does not block advisory-affected versions; nothing to do"
+        fi
+      shell: bash
+      working-directory: ${{ inputs.install-directory }}
+
     - name: Install dependencies
       run: composer install
       shell: bash


### PR DESCRIPTION
## Problem

The Mirror workflow's `integrity-check` fails on the `magento/project-community-edition:2.4.7` matrix job (runs [31449639497](https://github.com/mage-os/generate-mirror-repo-js/actions/runs/31449639497) and [31450763299](https://github.com/mage-os/generate-mirror-repo-js/actions/runs/31450763299)):

```
Root composer.json requires magento/product-community-edition 2.4.7 (exact version
match: 2.4.7 or 2.4.7.0), found magento/product-community-edition[2.4.7] but these
were not loaded, because they are affected by security advisories ("PKSA-db8d-773v-rd1n").
```

`PKSA-db8d-773v-rd1n` is CVE-2024-34102 (XXE, "CosmicSting"), affecting `>=2.4.7,<2.4.7-p1`.

Since 2.9, Composer removes advisory-affected packages from the **solver pool**, not just from the post-install audit report. All other matrix jobs pass; 2.4.7 is the one entry on Composer 2.10.2 whose own version is unpatched.

Bumping Composer cannot fix this one. The version under test *is* the vulnerable version, and always will be — unlike the July breakage (mage-os/github-actions#386), which was resolved by moving the matrix off a Composer release that had no patched build.

## Fix

Disable advisory blocking for these installs. This harness installs a specific historical release purely to diff it against the same release from `repo.magento.com`; refusing vulnerable versions is correct for a real store but defeats the purpose here. It does not weaken anything a user installs.

Notes on the implementation:

- The key is `policy.advisories.block` on Composer 2.10+, and `audit.block-insecure` before that (deprecated but still accepted in 2.10.2).
- Neither key exists on 1.x/2.2.x, where `composer config` exits non-zero — and nothing needs disabling there anyway.
- Neither key appears in `composer config --list`, so that can't be used to detect support.

The step therefore tries each key in turn and no-ops if neither is supported, which avoids version comparison against values like `2.10.2` vs `2.2.28`.

## Testing

Verified the snippet against the three Composer generations in the `usable` matrix:

| Composer | Result |
|---|---|
| `2.10.2` (18 entries) | sets `policy.advisories.block` |
| `2.2.28` (52 entries) | no-op, exit 0 |
| `1.10.26` (6 entries) | no-op, exit 0 |

Confirmed on 2.10.2 that it writes the expected nested config:

```json
{ "config": { "policy": { "advisories": { "block": false } } } }
```

This also prevents recurrence in general: any future advisory landing on one of the pinned dependencies in Magento's tree would otherwise break the checks again, which was the open item left over from #386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLy1odBZniuNwyTAh2AYgL