### PR TITLE
Patch Translation / LTS

### DIFF
--- a/bin/apply-security-patch.js
+++ b/bin/apply-security-patch.js
@@ -1,0 +1,171 @@
+/**
+ * Run with
+ *
+ * node bin/apply-security-patch.js --repoDir=/path/to/mageos-magento2 \
+ *   --patch=249-2026-08-001-CE.patch --branches=main,release/3.x --label=apsb26-92
+ *
+ * Translates an Adobe isolated security patch to source tree paths and applies
+ * it to each supported line, leaving one local branch per line for review.
+ *
+ * The patch itself is never written into the repository. Adobe's patch files are
+ * proprietary; the resulting change to Mage-OS's own source is not. Only the
+ * latter is committed.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const {execFileSync} = require('child_process');
+const parseOptions = require('parse-options');
+const {buildPackageMap, translatePatch} = require('../src/patch-translate');
+
+const options = parseOptions(
+  `$repoDir $patch $branches $label $direction @commit @help|h`,
+  process.argv
+);
+
+if (options.help || !options.repoDir || !options.patch || !options.branches) {
+  console.log(`Apply an Adobe isolated security patch across Mage-OS release lines.
+
+Usage:
+  node bin/apply-security-patch.js [OPTIONS]
+
+Options:
+  --repoDir=   Path to a mageos-magento2 checkout (required)
+  --patch=     Adobe patch file, or - for STDIN (required)
+  --branches=  Comma separated target branches (required), e.g. main,release/3.x
+  --label=     Short name used for the created branches (default: security-patch)
+  --direction= to-source (default) or none, to skip translation
+  --commit     Commit the applied result on each branch instead of leaving it staged
+
+Creates one branch per target named <label>-<branch>. Conflicts are left in the
+working tree for resolution and reported in the summary.
+`);
+  process.exit(1);
+}
+
+const repoDir = options.repoDir;
+const label = options.label || 'security-patch';
+const targets = options.branches.split(',').map(s => s.trim()).filter(Boolean);
+
+const git = (args, {cwd = repoDir, allowFailure = false} = {}) => {
+  try {
+    return execFileSync('git', ['-C', cwd, ...args], {
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024 * 256,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (exception) {
+    if (allowFailure) return null;
+    throw exception;
+  }
+};
+
+const patchText = options.patch === '-'
+  ? fs.readFileSync(0, 'utf8')
+  : fs.readFileSync(options.patch, 'utf8');
+
+const branchName = (target) => `${label}-${target.replace(/[^A-Za-z0-9._-]/g, '-')}`;
+
+const results = [];
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'mageos-patch-'));
+
+for (const target of targets) {
+  // The mapping is rebuilt per branch: a module can be added or renamed between
+  // lines, so a map built from one branch may not describe another.
+  let translated;
+  try {
+    const packageMap = buildPackageMap({repoDir, ref: target});
+    if (packageMap.size === 0) throw new Error(`no packages found at ${target}`);
+
+    if (options.direction === 'none') {
+      translated = {text: patchText, stats: {translated: 0, untranslated: []}};
+    } else {
+      translated = translatePatch(patchText, packageMap, 'to-source');
+      if (translated.stats.untranslated.length) {
+        results.push({
+          target,
+          status: 'UNMAPPED',
+          detail: translated.stats.untranslated.join(' '),
+        });
+        continue;
+      }
+    }
+  } catch (exception) {
+    results.push({target, status: 'ERROR', detail: exception.message});
+    continue;
+  }
+
+  const patchFile = path.join(scratch, `${branchName(target)}.patch`);
+  fs.writeFileSync(patchFile, translated.text);
+
+  const branch = branchName(target);
+  git(['branch', '-D', branch], {allowFailure: true});
+  if (git(['checkout', '-b', branch, target], {allowFailure: true}) === null) {
+    results.push({target, status: 'ERROR', detail: `cannot check out ${target}`});
+    continue;
+  }
+
+  git(['apply', '--3way', patchFile], {allowFailure: true});
+
+  const status = git(['status', '--porcelain'], {allowFailure: true}) || '';
+  const conflicts = status.split('\n')
+    .filter(line => /^(UU|AA|DD|AU|UA|DU|UD) /.test(line))
+    .map(line => line.slice(3));
+  const applied = status.split('\n').filter(line => /^[MA][ M] /.test(line)).length;
+
+  if (applied === 0 && conflicts.length === 0) {
+    results.push({target, status: 'NO-OP', detail: 'patch produced no changes'});
+    continue;
+  }
+
+  if (conflicts.length) {
+    results.push({
+      target,
+      status: 'CONFLICT',
+      detail: `${applied} applied, ${conflicts.length} conflicted: ${conflicts.join(' ')}`,
+      branch,
+    });
+    continue;
+  }
+
+  if (options.commit) {
+    git(['commit', '-m', `Port Adobe security patch ${label}`], {allowFailure: true});
+  }
+
+  results.push({target, status: 'CLEAN', detail: `${applied} files applied`, branch});
+}
+
+fs.rmSync(scratch, {recursive: true, force: true});
+
+const widthOf = (key, heading) =>
+  Math.max(heading.length, ...results.map(r => String(r[key] || '-').length)) + 2;
+
+const columns = [
+  ['target', 'TARGET'],
+  ['status', 'STATUS'],
+  ['branch', 'BRANCH'],
+  ['detail', 'DETAIL'],
+];
+
+console.log('');
+console.log(columns.map(([key, heading], i) =>
+  i === columns.length - 1 ? heading : heading.padEnd(widthOf(key, heading))
+).join(''));
+console.log('-'.repeat(
+  columns.slice(0, -1).reduce((sum, [key, heading]) => sum + widthOf(key, heading), 0) + 40
+));
+for (const result of results) {
+  console.log(columns.map(([key, heading], i) => {
+    const value = String(result[key] || (key === 'branch' ? '-' : ''));
+    return i === columns.length - 1 ? value : value.padEnd(widthOf(key, heading));
+  }).join(''));
+}
+console.log('');
+
+const failed = results.filter(r => r.status === 'ERROR' || r.status === 'UNMAPPED');
+const conflicted = results.filter(r => r.status === 'CONFLICT');
+if (conflicted.length) {
+  console.log(`${conflicted.length} branch(es) need conflict resolution before review.`);
+}
+process.exit(failed.length ? 1 : 0);

--- a/bin/apply-security-patch.js
+++ b/bin/apply-security-patch.js
@@ -46,9 +46,17 @@ branch with the markers in place, because that is the material a reviewer needs
 and because anything left in the working tree blocks the next checkout. Rejected
 hunks stay as untracked .rej files next to the file they belong to.
 
-Exits non-zero if any target needs a person: ERROR, UNMAPPED, CONFLICT or
-PARTIAL.
+Exits non-zero if any target needs a person: ERROR, UNMAPPED, REJECTED,
+CONFLICT or PARTIAL.
 `);
+  process.exit(1);
+}
+
+// Validated here because translatePatch's own check is never reached with the
+// user's value: anything but "none" used to fall through to to-source silently.
+const direction = options.direction || 'to-source';
+if (direction !== 'to-source' && direction !== 'none') {
+  console.error(`Unknown --direction "${direction}", expected to-source or none`);
   process.exit(1);
 }
 
@@ -103,7 +111,7 @@ for (const target of targets) {
   // lines, so a map built from one branch may not describe another.
   let translated;
   try {
-    if (options.direction === 'none') {
+    if (direction === 'none') {
       translated = {text: patchText, stats: {translated: 0, untranslated: []}};
     } else {
       // Only needed when translating, and it costs a git read per package.
@@ -157,12 +165,14 @@ for (const target of targets) {
   const rejectsBefore = new Set(listRejects());
 
   let applyOutput = '';
+  let applyFailed = false;
   try {
     execFileSync('git', ['-C', repoDir, ...applyArgs, patchFile], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (exception) {
+    applyFailed = true;
     applyOutput = `${exception.stdout || ''}${exception.stderr || ''}`;
   }
 
@@ -184,6 +194,19 @@ for (const target of targets) {
     if (openSection) openSection.push(line);
   }
 
+  // The file set the applied count is checked against. A plain diff -u has no
+  // diff --git headers, so fall back to the +++/--- markers; a body line that
+  // happens to start with them can only add a name no porcelain entry matches.
+  const patchFiles = new Set(sectionsByFile.keys());
+  if (patchFiles.size === 0) {
+    for (const line of translated.text.split('\n')) {
+      const marker = line.match(/^(?:---|\+\+\+) (\S+)/);
+      if (marker && marker[1] !== '/dev/null') {
+        patchFiles.add(marker[1].replace(/^[ab]\//, ''));
+      }
+    }
+  }
+
   // A file can fail to apply because the fix is already present by another
   // route, which looks identical to a real conflict in git's output. Comparing
   // that file's own added lines against the file on disk distinguishes the two
@@ -202,18 +225,22 @@ for (const target of targets) {
     return Math.round((found / added.length) * 100);
   };
 
-  const tot = sectionsByFile.size;
+  const tot = patchFiles.size;
+  const CONFLICT_CODES = /^(UU|AA|DD|AU|UA|DU|UD) /;
   const status = git(['status', '--porcelain'], {allowFailure: true}) || '';
   const conflicts = status.split('\n')
-    .filter(line => /^(UU|AA|DD|AU|UA|DU|UD) /.test(line))
+    .filter(line => CONFLICT_CODES.test(line))
     .map(line => line.slice(3));
-  // --3way stages what it applies; --reject leaves it unstaged. Count either,
-  // never the .rej files, and only files the patch actually names, so unrelated
-  // working tree noise cannot inflate the number.
+  // --3way stages what it applies; --reject leaves it unstaged. Count whatever
+  // the patch names that changed under any code — deletions and renames
+  // included, which an allowlist of M/A used to drop — never the .rej files,
+  // and nothing the patch does not name, so unrelated working tree noise
+  // cannot inflate the number. A rename line reads "old -> new"; the b side is
+  // the one the patch names.
   const applied = status.split('\n')
-    .filter(line => /^([ MA][MA] |[MA][ M] |\?\? )/.test(line) && !line.endsWith('.rej'))
-    .map(line => line.slice(3))
-    .filter(file => sectionsByFile.size === 0 || sectionsByFile.has(file))
+    .filter(line => line.trim() && !CONFLICT_CODES.test(line) && !line.endsWith('.rej'))
+    .map(line => line.slice(3).split(' -> ').pop())
+    .filter(file => patchFiles.has(file))
     .length;
 
   // Committed before classifying, and for conflicted and partial results too.
@@ -242,16 +269,38 @@ for (const target of targets) {
   }
 
   if (applied === 0 && conflicts.length === 0) {
-    results.push({
-      target,
-      status: blockedFiles.length ? 'REJECTED' : 'NO-OP',
-      detail: blockedFiles.length
-        ? `rolled back, blocked by: ${blockedFiles.map(file => {
-            const pct = alreadyPresent(file);
-            return pct === null ? file : `${file} (${pct}% of added lines already present)`;
-          }).join(' ')}`
-        : 'patch produced no changes',
-    });
+    // Nothing was committed, so the branch is an empty duplicate of its
+    // target. Leaving it around would make the next run demand --force for a
+    // branch holding no result.
+    git(['checkout', '--detach'], {allowFailure: true});
+    git(['branch', '-D', branch], {allowFailure: true});
+
+    if (blockedFiles.length) {
+      results.push({
+        target,
+        status: 'REJECTED',
+        detail: `rolled back, blocked by: ${blockedFiles.map(file => {
+          const pct = alreadyPresent(file);
+          return pct === null ? file : `${file} (${pct}% of added lines already present)`;
+        }).join(' ')}`,
+      });
+      continue;
+    }
+
+    // git apply can fail without a "patch failed" line — a corrupt patch, or a
+    // delete/rename of a file absent on this branch. That used to read as
+    // NO-OP, which looks like an already-applied patch and exits 0.
+    if (applyFailed) {
+      const lines = applyOutput.split('\n').map(line => line.trim()).filter(Boolean);
+      results.push({
+        target,
+        status: 'ERROR',
+        detail: lines.find(line => line.startsWith('error:')) || lines[0] || 'git apply failed',
+      });
+      continue;
+    }
+
+    results.push({target, status: 'NO-OP', detail: 'patch produced no changes'});
     continue;
   }
 
@@ -309,5 +358,5 @@ if (conflicted.length) {
   console.log(`${conflicted.length} branch(es) carry conflict markers and need resolving.`);
 }
 
-const needsAPerson = ['ERROR', 'UNMAPPED', 'CONFLICT', 'PARTIAL'];
+const needsAPerson = ['ERROR', 'UNMAPPED', 'REJECTED', 'CONFLICT', 'PARTIAL'];
 process.exit(results.some(r => needsAPerson.includes(r.status)) ? 1 : 0);

--- a/bin/apply-security-patch.js
+++ b/bin/apply-security-patch.js
@@ -106,7 +106,22 @@ for (const target of targets) {
     continue;
   }
 
-  git(['apply', '--3way', patchFile], {allowFailure: true});
+  // git apply is atomic: one rejected file rolls the whole patch back. Without
+  // the stderr the result is an unexplained "nothing applied", when in practice
+  // it usually means a single hunk is already present upstream.
+  let applyOutput = '';
+  try {
+    execFileSync('git', ['-C', repoDir, 'apply', '--3way', patchFile], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (exception) {
+    applyOutput = `${exception.stdout || ''}${exception.stderr || ''}`;
+  }
+
+  const blockedFiles = [...new Set(
+    [...applyOutput.matchAll(/error: patch failed: ([^:\n]+):/g)].map(match => match[1])
+  )];
 
   const status = git(['status', '--porcelain'], {allowFailure: true}) || '';
   const conflicts = status.split('\n')
@@ -115,7 +130,13 @@ for (const target of targets) {
   const applied = status.split('\n').filter(line => /^[MA][ M] /.test(line)).length;
 
   if (applied === 0 && conflicts.length === 0) {
-    results.push({target, status: 'NO-OP', detail: 'patch produced no changes'});
+    results.push({
+      target,
+      status: blockedFiles.length ? 'REJECTED' : 'NO-OP',
+      detail: blockedFiles.length
+        ? `rolled back, blocked by: ${blockedFiles.join(' ')}`
+        : 'patch produced no changes',
+    });
     continue;
   }
 

--- a/bin/apply-security-patch.js
+++ b/bin/apply-security-patch.js
@@ -20,7 +20,7 @@ const parseOptions = require('parse-options');
 const {buildPackageMap, translatePatch} = require('../src/patch-translate');
 
 const options = parseOptions(
-  `$repoDir $patch $branches $label $direction @commit @help|h`,
+  `$repoDir $patch $branches $label $direction @help|h`,
   process.argv
 );
 
@@ -36,10 +36,10 @@ Options:
   --branches=  Comma separated target branches (required), e.g. main,release/3.x
   --label=     Short name used for the created branches (default: security-patch)
   --direction= to-source (default) or none, to skip translation
-  --commit     Commit the applied result on each branch instead of leaving it staged
 
-Creates one branch per target named <label>-<branch>. Conflicts are left in the
-working tree for resolution and reported in the summary.
+Creates and commits one branch per target, named <label>-<branch>, and returns
+the repository to the ref it started on. Conflicts are left in the working tree
+for resolution and reported in the summary.
 `);
   process.exit(1);
 }
@@ -69,6 +69,11 @@ const branchName = (target) => `${label}-${target.replace(/[^A-Za-z0-9._-]/g, '-
 
 const results = [];
 const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'mageos-patch-'));
+
+// Restored at the end: the tool checks out a branch per target, and leaving the
+// repository on the last one makes a second run fail to check anything out.
+const startingRef = (git(['symbolic-ref', '--quiet', '--short', 'HEAD'], {allowFailure: true})
+  || git(['rev-parse', 'HEAD'], {allowFailure: true}) || '').trim();
 
 for (const target of targets) {
   // The mapping is rebuilt per branch: a module can be added or renamed between
@@ -123,6 +128,23 @@ for (const target of targets) {
     [...applyOutput.matchAll(/error: patch failed: ([^:\n]+):/g)].map(match => match[1])
   )];
 
+  // A file can fail to apply because the fix is already present by another
+  // route, which looks identical to a real conflict in git's output. Comparing
+  // the patch's added lines against the file on disk distinguishes the two well
+  // enough to tell a reviewer where to look. It is a signal, not a proof.
+  const alreadyPresent = (file) => {
+    const target = path.join(repoDir, file);
+    if (!fs.existsSync(target)) return null;
+    const contents = fs.readFileSync(target, 'utf8');
+    const added = translated.text.split('\n')
+      .filter(line => line.startsWith('+') && !line.startsWith('+++'))
+      .map(line => line.slice(1).trim())
+      .filter(line => line.length > 12);
+    if (added.length === 0) return null;
+    const found = added.filter(line => contents.includes(line)).length;
+    return Math.round((found / added.length) * 100);
+  };
+
   const status = git(['status', '--porcelain'], {allowFailure: true}) || '';
   const conflicts = status.split('\n')
     .filter(line => /^(UU|AA|DD|AU|UA|DU|UD) /.test(line))
@@ -134,7 +156,10 @@ for (const target of targets) {
       target,
       status: blockedFiles.length ? 'REJECTED' : 'NO-OP',
       detail: blockedFiles.length
-        ? `rolled back, blocked by: ${blockedFiles.join(' ')}`
+        ? `rolled back, blocked by: ${blockedFiles.map(file => {
+            const pct = alreadyPresent(file);
+            return pct === null ? file : `${file} (${pct}% of added lines already present)`;
+          }).join(' ')}`
         : 'patch produced no changes',
     });
     continue;
@@ -150,14 +175,21 @@ for (const target of targets) {
     continue;
   }
 
-  if (options.commit) {
-    git(['commit', '-m', `Port Adobe security patch ${label}`], {allowFailure: true});
-  }
+  // Always committed: the branch exists only to hold this result, and leaving it
+  // staged means the tool cannot leave the branch, so a second target or a
+  // second run cannot check anything out.
+  git(['commit', '-m', `Port Adobe security patch ${label}`], {allowFailure: true});
 
   results.push({target, status: 'CLEAN', detail: `${applied} files applied`, branch});
 }
 
 fs.rmSync(scratch, {recursive: true, force: true});
+
+if (startingRef) {
+  // Staged results live on their own branches, so returning to the starting ref
+  // does not discard anything.
+  git(['checkout', startingRef], {allowFailure: true});
+}
 
 const widthOf = (key, heading) =>
   Math.max(heading.length, ...results.map(r => String(r[key] || '-').length)) + 2;

--- a/bin/apply-security-patch.js
+++ b/bin/apply-security-patch.js
@@ -20,7 +20,7 @@ const parseOptions = require('parse-options');
 const {buildPackageMap, translatePatch} = require('../src/patch-translate');
 
 const options = parseOptions(
-  `$repoDir $patch $branches $label $direction @help|h`,
+  `$repoDir $patch $branches $label $direction @partial @help|h`,
   process.argv
 );
 
@@ -36,6 +36,8 @@ Options:
   --branches=  Comma separated target branches (required), e.g. main,release/3.x
   --label=     Short name used for the created branches (default: security-patch)
   --direction= to-source (default) or none, to skip translation
+  --partial    Apply what applies and leave .rej files for the rest, instead of
+               rolling the whole patch back when one file conflicts
 
 Creates and commits one branch per target, named <label>-<branch>, and returns
 the repository to the ref it started on. Conflicts are left in the working tree
@@ -114,15 +116,24 @@ for (const target of targets) {
   // git apply is atomic: one rejected file rolls the whole patch back. Without
   // the stderr the result is an unexplained "nothing applied", when in practice
   // it usually means a single hunk is already present upstream.
+  // --3way merges using the patch's blob ids and is atomic: one rejected file
+  // rolls the whole patch back. --reject applies what it can and leaves .rej
+  // behind, which is what you want for a large patch where one hunk has drifted.
+  // git refuses the two together, so this is a mode, not a flag.
+  const applyArgs = options.partial ? ['apply', '--reject'] : ['apply', '--3way'];
+
   let applyOutput = '';
   try {
-    execFileSync('git', ['-C', repoDir, 'apply', '--3way', patchFile], {
+    execFileSync('git', ['-C', repoDir, ...applyArgs, patchFile], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (exception) {
     applyOutput = `${exception.stdout || ''}${exception.stderr || ''}`;
   }
+
+  const rejects = (git(['ls-files', '--others', '--exclude-standard'], {allowFailure: true}) || '')
+    .split('\n').filter(f => f.endsWith('.rej'));
 
   const blockedFiles = [...new Set(
     [...applyOutput.matchAll(/error: patch failed: ([^:\n]+):/g)].map(match => match[1])
@@ -145,11 +156,36 @@ for (const target of targets) {
     return Math.round((found / added.length) * 100);
   };
 
+  const tot = (translated.text.match(/^diff --git /gm) || []).length;
   const status = git(['status', '--porcelain'], {allowFailure: true}) || '';
   const conflicts = status.split('\n')
     .filter(line => /^(UU|AA|DD|AU|UA|DU|UD) /.test(line))
     .map(line => line.slice(3));
-  const applied = status.split('\n').filter(line => /^[MA][ M] /.test(line)).length;
+  // --3way stages what it applies; --reject leaves it unstaged. Count either,
+  // and never count the .rej files themselves.
+  const applied = status.split('\n')
+    .filter(line => /^([ MA][MA] |[MA][ M] |\?\? )/.test(line) && !line.endsWith('.rej'))
+    .length;
+
+  // Committed before classifying, and for partial results too: the branch exists
+  // only to hold this result, and anything left in the working tree stops the
+  // tool leaving the branch, so the next target or run cannot check out. Rejects
+  // stay uncommitted — they are working notes for whoever resolves the conflict.
+  if (applied > 0 && conflicts.length === 0) {
+    git(['add', '--all', '--', ':!*.rej'], {allowFailure: true});
+    git(['commit', '-m', `Port Adobe security patch ${label}`], {allowFailure: true});
+  }
+
+  if (rejects.length) {
+    results.push({
+      target,
+      status: 'PARTIAL',
+      detail: `${applied} of ${tot} applied, ${rejects.length} rejected: ` +
+        rejects.map(f => f.replace(/\.rej$/, '')).join(' '),
+      branch,
+    });
+    continue;
+  }
 
   if (applied === 0 && conflicts.length === 0) {
     results.push({
@@ -174,11 +210,6 @@ for (const target of targets) {
     });
     continue;
   }
-
-  // Always committed: the branch exists only to hold this result, and leaving it
-  // staged means the tool cannot leave the branch, so a second target or a
-  // second run cannot check anything out.
-  git(['commit', '-m', `Port Adobe security patch ${label}`], {allowFailure: true});
 
   results.push({target, status: 'CLEAN', detail: `${applied} files applied`, branch});
 }

--- a/bin/apply-security-patch.js
+++ b/bin/apply-security-patch.js
@@ -20,7 +20,7 @@ const parseOptions = require('parse-options');
 const {buildPackageMap, translatePatch} = require('../src/patch-translate');
 
 const options = parseOptions(
-  `$repoDir $patch $branches $label $direction @partial @help|h`,
+  `$repoDir $patch $branches $label $direction @partial @force @help|h`,
   process.argv
 );
 
@@ -38,10 +38,16 @@ Options:
   --direction= to-source (default) or none, to skip translation
   --partial    Apply what applies and leave .rej files for the rest, instead of
                rolling the whole patch back when one file conflicts
+  --force      Replace an existing <label>-<branch>, discarding what is on it
 
 Creates and commits one branch per target, named <label>-<branch>, and returns
-the repository to the ref it started on. Conflicts are left in the working tree
-for resolution and reported in the summary.
+the repository to the ref it started on. A conflicted result is committed to its
+branch with the markers in place, because that is the material a reviewer needs
+and because anything left in the working tree blocks the next checkout. Rejected
+hunks stay as untracked .rej files next to the file they belong to.
+
+Exits non-zero if any target needs a person: ERROR, UNMAPPED, CONFLICT or
+PARTIAL.
 `);
   process.exit(1);
 }
@@ -69,6 +75,21 @@ const patchText = options.patch === '-'
 
 const branchName = (target) => `${label}-${target.replace(/[^A-Za-z0-9._-]/g, '-')}`;
 
+const listRejects = () => (git(['ls-files', '--others', '--exclude-standard'], {allowFailure: true}) || '')
+  .split('\n').filter(file => file.endsWith('.rej'));
+
+// Untracked .rej files are this tool's own output from an earlier run, and a
+// reviewer is meant to still have them, so they do not count as a dirty tree.
+const trackedChanges = (git(['status', '--porcelain'], {allowFailure: true}) || '')
+  .split('\n').filter(Boolean).filter(line => !line.endsWith('.rej'));
+
+if (trackedChanges.length) {
+  console.error(`${repoDir} has uncommitted changes. Applying a patch on top of them would`);
+  console.error('mix them into the result branches. Commit or stash them first:');
+  trackedChanges.forEach(line => console.error(`  ${line}`));
+  process.exit(1);
+}
+
 const results = [];
 const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'mageos-patch-'));
 
@@ -82,12 +103,13 @@ for (const target of targets) {
   // lines, so a map built from one branch may not describe another.
   let translated;
   try {
-    const packageMap = buildPackageMap({repoDir, ref: target});
-    if (packageMap.size === 0) throw new Error(`no packages found at ${target}`);
-
     if (options.direction === 'none') {
       translated = {text: patchText, stats: {translated: 0, untranslated: []}};
     } else {
+      // Only needed when translating, and it costs a git read per package.
+      const packageMap = buildPackageMap({repoDir, ref: target});
+      if (packageMap.size === 0) throw new Error(`no packages found at ${target}`);
+
       translated = translatePatch(patchText, packageMap, 'to-source');
       if (translated.stats.untranslated.length) {
         results.push({
@@ -107,7 +129,15 @@ for (const target of targets) {
   fs.writeFileSync(patchFile, translated.text);
 
   const branch = branchName(target);
-  git(['branch', '-D', branch], {allowFailure: true});
+  const exists = git(['rev-parse', '--verify', '--quiet', `refs/heads/${branch}`], {allowFailure: true});
+  // A previous run's branch can hold a resolved conflict. Replacing it silently
+  // would throw that away, so it takes saying so.
+  if (exists && !options.force) {
+    results.push({target, status: 'ERROR', detail: `branch ${branch} already exists, --force to replace`});
+    continue;
+  }
+  if (exists) git(['branch', '-D', branch], {allowFailure: true});
+
   if (git(['checkout', '-b', branch, target], {allowFailure: true}) === null) {
     results.push({target, status: 'ERROR', detail: `cannot check out ${target}`});
     continue;
@@ -122,6 +152,10 @@ for (const target of targets) {
   // git refuses the two together, so this is a mode, not a flag.
   const applyArgs = options.partial ? ['apply', '--reject'] : ['apply', '--3way'];
 
+  // Rejects from an earlier target are still untracked here, so only the ones
+  // this apply produces are attributed to this target.
+  const rejectsBefore = new Set(listRejects());
+
   let applyOutput = '';
   try {
     execFileSync('git', ['-C', repoDir, ...applyArgs, patchFile], {
@@ -132,22 +166,34 @@ for (const target of targets) {
     applyOutput = `${exception.stdout || ''}${exception.stderr || ''}`;
   }
 
-  const rejects = (git(['ls-files', '--others', '--exclude-standard'], {allowFailure: true}) || '')
-    .split('\n').filter(f => f.endsWith('.rej'));
+  const rejects = listRejects().filter(file => !rejectsBefore.has(file));
 
   const blockedFiles = [...new Set(
     [...applyOutput.matchAll(/error: patch failed: ([^:\n]+):/g)].map(match => match[1])
   )];
 
+  // Keyed by the b side path, which is the form git reports in "patch failed".
+  const sectionsByFile = new Map();
+  let openSection = null;
+  for (const line of translated.text.split('\n')) {
+    const header = line.match(/^diff --git (\S+) (\S+)/);
+    if (header) {
+      openSection = [];
+      sectionsByFile.set(header[2].replace(/^[ab]\//, ''), openSection);
+    }
+    if (openSection) openSection.push(line);
+  }
+
   // A file can fail to apply because the fix is already present by another
   // route, which looks identical to a real conflict in git's output. Comparing
-  // the patch's added lines against the file on disk distinguishes the two well
-  // enough to tell a reviewer where to look. It is a signal, not a proof.
+  // that file's own added lines against the file on disk distinguishes the two
+  // well enough to tell a reviewer where to look. It is a signal, not a proof.
   const alreadyPresent = (file) => {
     const target = path.join(repoDir, file);
-    if (!fs.existsSync(target)) return null;
+    const section = sectionsByFile.get(file);
+    if (!section || !fs.existsSync(target)) return null;
     const contents = fs.readFileSync(target, 'utf8');
-    const added = translated.text.split('\n')
+    const added = section
       .filter(line => line.startsWith('+') && !line.startsWith('+++'))
       .map(line => line.slice(1).trim())
       .filter(line => line.length > 12);
@@ -156,24 +202,32 @@ for (const target of targets) {
     return Math.round((found / added.length) * 100);
   };
 
-  const tot = (translated.text.match(/^diff --git /gm) || []).length;
+  const tot = sectionsByFile.size;
   const status = git(['status', '--porcelain'], {allowFailure: true}) || '';
   const conflicts = status.split('\n')
     .filter(line => /^(UU|AA|DD|AU|UA|DU|UD) /.test(line))
     .map(line => line.slice(3));
   // --3way stages what it applies; --reject leaves it unstaged. Count either,
-  // and never count the .rej files themselves.
+  // never the .rej files, and only files the patch actually names, so unrelated
+  // working tree noise cannot inflate the number.
   const applied = status.split('\n')
     .filter(line => /^([ MA][MA] |[MA][ M] |\?\? )/.test(line) && !line.endsWith('.rej'))
+    .map(line => line.slice(3))
+    .filter(file => sectionsByFile.size === 0 || sectionsByFile.has(file))
     .length;
 
-  // Committed before classifying, and for partial results too: the branch exists
-  // only to hold this result, and anything left in the working tree stops the
-  // tool leaving the branch, so the next target or run cannot check out. Rejects
-  // stay uncommitted — they are working notes for whoever resolves the conflict.
-  if (applied > 0 && conflicts.length === 0) {
+  // Committed before classifying, and for conflicted and partial results too.
+  // Anything left in the working tree blocks the next target's checkout, which
+  // used to make one conflict fail every target after it. Conflict markers are
+  // worth committing: the branch exists only to hold this result, and the
+  // markers are what a reviewer resolves. Rejects stay uncommitted, as working
+  // notes next to the file they belong to.
+  if (applied > 0 || conflicts.length) {
     git(['add', '--all', '--', ':!*.rej'], {allowFailure: true});
-    git(['commit', '-m', `Port Adobe security patch ${label}`], {allowFailure: true});
+    const subject = conflicts.length
+      ? `Port Adobe security patch ${label} (unresolved conflicts)`
+      : `Port Adobe security patch ${label}`;
+    git(['commit', '-m', subject], {allowFailure: true});
   }
 
   if (rejects.length) {
@@ -217,9 +271,12 @@ for (const target of targets) {
 fs.rmSync(scratch, {recursive: true, force: true});
 
 if (startingRef) {
-  // Staged results live on their own branches, so returning to the starting ref
-  // does not discard anything.
-  git(['checkout', startingRef], {allowFailure: true});
+  // Every result is committed to its own branch, so returning to the starting
+  // ref does not discard anything.
+  if (git(['checkout', startingRef], {allowFailure: true}) === null) {
+    const now = (git(['rev-parse', '--abbrev-ref', 'HEAD'], {allowFailure: true}) || '?').trim();
+    console.error(`Warning: could not return to ${startingRef}; the checkout is left on ${now}`);
+  }
 }
 
 const widthOf = (key, heading) =>
@@ -247,9 +304,10 @@ for (const result of results) {
 }
 console.log('');
 
-const failed = results.filter(r => r.status === 'ERROR' || r.status === 'UNMAPPED');
 const conflicted = results.filter(r => r.status === 'CONFLICT');
 if (conflicted.length) {
-  console.log(`${conflicted.length} branch(es) need conflict resolution before review.`);
+  console.log(`${conflicted.length} branch(es) carry conflict markers and need resolving.`);
 }
-process.exit(failed.length ? 1 : 0);
+
+const needsAPerson = ['ERROR', 'UNMAPPED', 'CONFLICT', 'PARTIAL'];
+process.exit(results.some(r => needsAPerson.includes(r.status)) ? 1 : 0);

--- a/bin/translate-patch.js
+++ b/bin/translate-patch.js
@@ -1,0 +1,71 @@
+/**
+ * Run with
+ *
+ * node bin/translate-patch.js --repoDir=/path/to/mageos-magento2 --ref=main --direction=to-source --patch=adobe.patch
+ */
+
+const fs = require('fs');
+const parseOptions = require('parse-options');
+const {buildPackageMap, translatePatch} = require('../src/patch-translate');
+
+const options = parseOptions(
+  `$repoDir $ref $direction $patch $out @help|h`,
+  process.argv
+);
+
+if (options.help || !options.repoDir || !options.patch) {
+  console.log(`Rewrite patch file paths between the Magento source tree layout and the
+installed Composer vendor layout.
+
+Adobe ships isolated security patches against an installed tree
+(vendor/magento/module-cms/...). This rewrites them to source tree paths
+(app/code/Magento/Cms/...) so they can be applied to this repository.
+
+The package mapping is read from each package's own composer.json at the given
+ref, so it cannot drift from what the build produces.
+
+Usage:
+  node bin/translate-patch.js [OPTIONS]
+
+Options:
+  --repoDir=   Path to a mageos-magento2 checkout (required)
+  --ref=       Git ref to read the package mapping from (default: main)
+  --direction= to-source (vendor -> app/code) or to-vendor (default: to-source)
+  --patch=     Patch file to translate, or - for STDIN (required)
+  --out=       Write to this file instead of STDOUT
+`);
+  process.exit(1);
+}
+
+const ref = options.ref || 'main';
+const direction = options.direction || 'to-source';
+
+const patchText = options.patch === '-'
+  ? fs.readFileSync(0, 'utf8')
+  : fs.readFileSync(options.patch, 'utf8');
+
+const packageMap = buildPackageMap({repoDir: options.repoDir, ref});
+if (packageMap.size === 0) {
+  console.error(`No packages found at ref "${ref}" in ${options.repoDir}`);
+  process.exit(1);
+}
+
+const {text, stats} = translatePatch(patchText, packageMap, direction);
+
+if (options.out) {
+  fs.writeFileSync(options.out, text);
+} else {
+  process.stdout.write(text);
+}
+
+console.error(`${packageMap.size} packages mapped from ${ref}`);
+console.error(`${stats.translated} path references translated`);
+
+// Anything left untranslated is a path the build does not own: a third party
+// package, or a file outside the packaged tree. Applying such a patch would
+// silently drop those hunks, so fail rather than emit a partial result.
+if (stats.untranslated.length) {
+  console.error(`${stats.untranslated.length} could not be translated:`);
+  stats.untranslated.forEach(path => console.error(`  ${path}`));
+  process.exit(2);
+}

--- a/bin/translate-patch.js
+++ b/bin/translate-patch.js
@@ -61,6 +61,13 @@ if (options.out) {
 console.error(`${packageMap.size} packages mapped from ${ref}`);
 console.error(`${stats.translated} path references translated`);
 
+// Dropped hunks change what the patch does, so they are always reported even
+// though they are not an error.
+if (stats.dropped && stats.dropped.length) {
+  console.error(`${stats.dropped.length} install-only path(s) dropped:`);
+  stats.dropped.forEach(path => console.error(`  ${path}`));
+}
+
 // Anything left untranslated is a path the build does not own: a third party
 // package, or a file outside the packaged tree. Applying such a patch would
 // silently drop those hunks, so fail rather than emit a partial result.

--- a/src/patch-translate.js
+++ b/src/patch-translate.js
@@ -8,8 +8,11 @@
  * byte-identical files, so the rewrite is total: no content is interpreted.
  */
 
+const fs = require('fs');
+const path = require('path');
 const {execFileSync} = require('child_process');
 const packagesConfig = require('./build-config/packages-config');
+const {buildConfig: releaseInstructions} = require('./build-config/mageos-release-build-config');
 
 /**
  * Directories whose immediate subdirectories are each their own package, as
@@ -17,17 +20,24 @@ const packagesConfig = require('./build-config/packages-config');
  */
 const packageDirsFor = (definition) => (definition.packageDirs || []).map(entry => entry.dir);
 
-const individualDirsFor = (definition) => (definition.packageIndividual || [])
-  .map(entry => entry.dir)
-  // dir '' is the base package, which is every path not claimed by another
-  // entry; it has no directory of its own to map.
-  .filter(dir => typeof dir === 'string' && dir !== '');
+const individualEntriesFor = (definition) => (definition.packageIndividual || [])
+  .filter(entry => typeof entry.dir === 'string');
 
 const readComposerName = (git, dir) => {
   const raw = git(['show', `${git.ref}:${dir}/composer.json`], {allowFailure: true});
   if (!raw) return null;
   try {
     const name = JSON.parse(raw).name;
+    return typeof name === 'string' && name.includes('/') ? name : null;
+  } catch (exception) {
+    return null;
+  }
+};
+
+const templateName = (composerJsonPath) => {
+  if (!composerJsonPath || !fs.existsSync(composerJsonPath)) return null;
+  try {
+    const name = JSON.parse(fs.readFileSync(composerJsonPath, 'utf8')).name;
     return typeof name === 'string' && name.includes('/') ? name : null;
   } catch (exception) {
     return null;
@@ -57,31 +67,97 @@ const gitFor = (repoDir, ref) => {
  * derived from the directory name: module directory CamelCase does not map to
  * package kebab-case by any rule the build itself relies on.
  */
-const buildPackageMap = ({repoDir, ref, definitionKey = 'magento2'}) => {
-  const definition = packagesConfig[definitionKey];
-  if (!definition) {
-    throw new Error(`No package definition "${definitionKey}" in packages-config`);
-  }
-
+const addRepoPackages = (toSource, {repoDir, ref, definition}) => {
   const git = gitFor(repoDir, ref);
-  const toSource = new Map();
 
   for (const dir of packageDirsFor(definition)) {
     const listing = git(['ls-tree', '--name-only', `${ref}:${dir}`], {allowFailure: true});
     if (!listing) continue;
     for (const entry of listing.split('\n').filter(Boolean)) {
-      const packageDir = `${dir}/${entry.replace(/\/$/, '')}`;
-      const name = readComposerName(git, packageDir);
-      if (name) toSource.set(name, packageDir);
+      // dir '' means the repository root is the container, so each top level
+      // directory is itself a package (inventory and security-package do this).
+      const name_ = entry.replace(/\/$/, '');
+      const packageDir = dir ? `${dir}/${name_}` : name_;
+      const pkgName = readComposerName(git, packageDir);
+      if (pkgName) toSource.set(pkgName, packageDir);
     }
   }
 
-  for (const dir of individualDirsFor(definition)) {
-    const name = readComposerName(git, dir);
-    if (name) toSource.set(name, dir);
+  for (const entry of individualEntriesFor(definition)) {
+    // The base package has no composer.json in the tree; its name comes from the
+    // template the build uses, and it maps to the repository root, which is where
+    // lib/web, app/etc and the other unpackaged paths live.
+    const name = entry.dir
+      ? readComposerName(git, entry.dir)
+      : templateName(entry.composerJsonPath);
+    if (name) toSource.set(name, entry.dir);
   }
 
   return toSource;
+};
+
+const dedupeBy = (entries, keyOf) => {
+  const seen = new Set();
+  return entries.filter(entry => {
+    const key = keyOf(entry);
+    if (typeof key !== 'string' || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+
+/** Whatever the checkout is currently on, so callers need not know each
+ *  repository's default branch name (some use mage-os rather than main). */
+const defaultRefOf = (repoDir) => {
+  const git = gitFor(repoDir, 'HEAD');
+  const head = git(['rev-parse', 'HEAD'], {allowFailure: true});
+  return head ? head.trim() : null;
+};
+
+const repoDirName = (repoUrl) => path.basename(repoUrl).replace(/\.git$/, '');
+
+/**
+ * A patch may touch packages from any repository the distribution is built
+ * from, not just magento2: the inventory, page builder and security package
+ * modules all live in their own repositories. Passing gitRepoDir builds the map
+ * across every repository present there, which is the layout the release build
+ * already clones into.
+ */
+const buildPackageMap = ({repoDir, ref, definitionKey = 'magento2', gitRepoDir}) => {
+  const toSource = new Map();
+
+  if (gitRepoDir) {
+    // Every directory layout any repository uses, applied to every checkout
+    // found. Probing rather than matching config keys to directory names keeps
+    // this working whichever set of repositories is cloned, and whatever they
+    // are named locally.
+    const everyLayout = {
+      packageDirs: dedupeBy(
+        Object.values(packagesConfig).flatMap(d => d.packageDirs || []),
+        entry => entry.dir
+      ),
+      packageIndividual: dedupeBy(
+        Object.values(packagesConfig).flatMap(d => d.packageIndividual || []),
+        entry => entry.dir
+      ),
+    };
+
+    for (const entry of fs.readdirSync(gitRepoDir, {withFileTypes: true})) {
+      if (!entry.isDirectory()) continue;
+      const dir = path.join(gitRepoDir, entry.name);
+      if (!fs.existsSync(path.join(dir, '.git'))) continue;
+      const head = ref || defaultRefOf(dir);
+      if (!head) continue;
+      addRepoPackages(toSource, {repoDir: dir, ref: head, definition: everyLayout});
+    }
+    return toSource;
+  }
+
+  const definition = packagesConfig[definitionKey];
+  if (!definition) {
+    throw new Error(`No package definition "${definitionKey}" in packages-config`);
+  }
+  return addRepoPackages(toSource, {repoDir, ref, definition});
 };
 
 /**
@@ -103,14 +179,23 @@ const makeTranslators = (packageMap) => {
 
   const vendorToSource = (path) => {
     const match = path.match(/^vendor\/([^/]+\/[^/]+)(\/.*)?$/);
-    if (!match) return null;
+    // Some upstream patches address root relative paths directly, e.g.
+    // lib/web/mage/menu.js or app/etc/di.xml. Those are already source tree
+    // paths, so they pass through rather than counting as a failed lookup.
+    if (!match) return path.startsWith('vendor/') ? null : path;
     const [, name, rest] = match;
-    // The source tree declares magento/*; the published packages are renamed to
-    // mage-os/* at build time, so an incoming patch may use either vendor.
-    const candidates = [name, name.replace(/^mage-os\//, 'magento/')];
+    // Adobe patches reference magento/*, the published packages are renamed to
+    // mage-os/*, and a checkout may hold either depending on whether a release
+    // build has rewritten its composer.json files. Try both directions.
+    const candidates = [
+      name,
+      name.replace(/^mage-os\//, 'magento/'),
+      name.replace(/^magento\//, 'mage-os/'),
+    ];
     for (const candidate of candidates) {
+      if (!packageMap.has(candidate)) continue;
       const dir = packageMap.get(candidate);
-      if (dir) return `${dir}${rest || ''}`;
+      return dir ? `${dir}${rest || ''}` : (rest || '').replace(/^\//, '');
     }
     return null;
   };

--- a/src/patch-translate.js
+++ b/src/patch-translate.js
@@ -157,6 +157,11 @@ const buildPackageMap = ({repoDir, ref, definitionKey = 'magento2', gitRepoDir})
   if (!definition) {
     throw new Error(`No package definition "${definitionKey}" in packages-config`);
   }
+  // Every read below tolerates failure, so a ref that does not exist would
+  // otherwise surface as an empty map and a patch that translates nothing.
+  if (!gitFor(repoDir, ref)(['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], {allowFailure: true})) {
+    throw new Error(`ref "${ref}" not found in ${repoDir}`);
+  }
   return addRepoPackages(toSource, {repoDir, ref, definition});
 };
 

--- a/src/patch-translate.js
+++ b/src/patch-translate.js
@@ -243,6 +243,11 @@ const translatePatch = (patchText, packageMap, direction) => {
 
   const stats = {translated: 0, untranslated: [], dropped: []};
 
+  // git apply rejects a patch that does not end in a newline. Dropping the last
+  // section would otherwise take the trailing newline with it, and the isolated
+  // patches put their install-only marker last.
+  const endsWithNewline = patchText.endsWith('\n');
+
   // Sections are split on diff --git so a dropped file takes its hunks with it.
   const sections = [];
   for (const line of patchText.split('\n')) {
@@ -296,7 +301,8 @@ const translatePatch = (patchText, packageMap, direction) => {
 
   stats.untranslated = [...new Set(stats.untranslated)];
   stats.dropped = [...new Set(stats.dropped)];
-  return {text, stats};
+  const output = endsWithNewline && !text.endsWith('\n') ? `${text}\n` : text;
+  return {text: output, stats};
 };
 
 module.exports = {buildPackageMap, translatePatch};

--- a/src/patch-translate.js
+++ b/src/patch-translate.js
@@ -1,0 +1,185 @@
+/**
+ * Translates patch file paths between the Magento source tree layout
+ * (app/code/Magento/Cms) and the installed Composer layout
+ * (vendor/magento/module-cms).
+ *
+ * Adobe ships isolated security patches against an installed tree, so applying
+ * one to this repository means rewriting every path in it. The two trees hold
+ * byte-identical files, so the rewrite is total: no content is interpreted.
+ */
+
+const {execFileSync} = require('child_process');
+const packagesConfig = require('./build-config/packages-config');
+
+/**
+ * Directories whose immediate subdirectories are each their own package, as
+ * opposed to packageIndividual entries which are a single package apiece.
+ */
+const packageDirsFor = (definition) => (definition.packageDirs || []).map(entry => entry.dir);
+
+const individualDirsFor = (definition) => (definition.packageIndividual || [])
+  .map(entry => entry.dir)
+  // dir '' is the base package, which is every path not claimed by another
+  // entry; it has no directory of its own to map.
+  .filter(dir => typeof dir === 'string' && dir !== '');
+
+const readComposerName = (git, dir) => {
+  const raw = git(['show', `${git.ref}:${dir}/composer.json`], {allowFailure: true});
+  if (!raw) return null;
+  try {
+    const name = JSON.parse(raw).name;
+    return typeof name === 'string' && name.includes('/') ? name : null;
+  } catch (exception) {
+    return null;
+  }
+};
+
+const gitFor = (repoDir, ref) => {
+  const git = (args, {allowFailure = false} = {}) => {
+    try {
+      return execFileSync('git', ['-C', repoDir, ...args], {
+        encoding: 'utf8',
+        maxBuffer: 1024 * 1024 * 256,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+    } catch (exception) {
+      if (allowFailure) return null;
+      throw exception;
+    }
+  };
+  git.ref = ref;
+  return git;
+};
+
+/**
+ * Builds the package-name <-> source-directory mapping by reading each
+ * package's own composer.json out of the given ref. The names are never
+ * derived from the directory name: module directory CamelCase does not map to
+ * package kebab-case by any rule the build itself relies on.
+ */
+const buildPackageMap = ({repoDir, ref, definitionKey = 'magento2'}) => {
+  const definition = packagesConfig[definitionKey];
+  if (!definition) {
+    throw new Error(`No package definition "${definitionKey}" in packages-config`);
+  }
+
+  const git = gitFor(repoDir, ref);
+  const toSource = new Map();
+
+  for (const dir of packageDirsFor(definition)) {
+    const listing = git(['ls-tree', '--name-only', `${ref}:${dir}`], {allowFailure: true});
+    if (!listing) continue;
+    for (const entry of listing.split('\n').filter(Boolean)) {
+      const packageDir = `${dir}/${entry.replace(/\/$/, '')}`;
+      const name = readComposerName(git, packageDir);
+      if (name) toSource.set(name, packageDir);
+    }
+  }
+
+  for (const dir of individualDirsFor(definition)) {
+    const name = readComposerName(git, dir);
+    if (name) toSource.set(name, dir);
+  }
+
+  return toSource;
+};
+
+/**
+ * Longest-first so that lib/internal/Magento/Framework/Amqp is matched before
+ * the lib/internal/Magento/Framework that contains it.
+ */
+const sortedByDepth = (map) => [...map.entries()].sort((a, b) => b[1].length - a[1].length);
+
+const makeTranslators = (packageMap) => {
+  const byDepth = sortedByDepth(packageMap);
+
+  const sourceToVendor = (path) => {
+    for (const [name, dir] of byDepth) {
+      if (path === dir) return `vendor/${name}`;
+      if (path.startsWith(`${dir}/`)) return `vendor/${name}${path.slice(dir.length)}`;
+    }
+    return null;
+  };
+
+  const vendorToSource = (path) => {
+    const match = path.match(/^vendor\/([^/]+\/[^/]+)(\/.*)?$/);
+    if (!match) return null;
+    const [, name, rest] = match;
+    // The source tree declares magento/*; the published packages are renamed to
+    // mage-os/* at build time, so an incoming patch may use either vendor.
+    const candidates = [name, name.replace(/^mage-os\//, 'magento/')];
+    for (const candidate of candidates) {
+      const dir = packageMap.get(candidate);
+      if (dir) return `${dir}${rest || ''}`;
+    }
+    return null;
+  };
+
+  return {sourceToVendor, vendorToSource};
+};
+
+// Matches the path-bearing lines of a unified diff. Trailing text after the
+// path (timestamps, tabs) is preserved verbatim.
+const DIFF_GIT = /^(diff --git )(\S+)( )(\S+)(.*)$/;
+const FILE_MARKER = /^(---|\+\+\+)(\s+)(\S+)(.*)$/;
+const RENAME = /^(rename (?:from|to) )(.+)$/;
+const BINARY = /^(Binary files )(\S+)( and )(\S+)( differ)$/;
+
+/**
+ * Strips a leading a/ or b/ so the path can be looked up, and restores it after.
+ * Real-world patches appear both with and without the prefix.
+ */
+const withPrefix = (path, translate) => {
+  const match = path.match(/^([ab]\/)(.*)$/);
+  const prefix = match ? match[1] : '';
+  const bare = match ? match[2] : path;
+  if (bare === '/dev/null' || path === '/dev/null') return null;
+  const translated = translate(bare);
+  return translated === null ? null : prefix + translated;
+};
+
+const translatePatch = (patchText, packageMap, direction) => {
+  const {sourceToVendor, vendorToSource} = makeTranslators(packageMap);
+  const translate = direction === 'to-vendor' ? sourceToVendor : vendorToSource;
+  if (direction !== 'to-vendor' && direction !== 'to-source') {
+    throw new Error(`Unknown direction "${direction}", expected to-vendor or to-source`);
+  }
+
+  const stats = {translated: 0, untranslated: []};
+
+  const rewrite = (path) => {
+    if (path === '/dev/null') return path;
+    const out = withPrefix(path, translate);
+    if (out === null) {
+      stats.untranslated.push(path.replace(/^[ab]\//, ''));
+      return path;
+    }
+    stats.translated++;
+    return out;
+  };
+
+  const text = patchText.split('\n').map(line => {
+    let match = line.match(DIFF_GIT);
+    if (match) {
+      return match[1] + rewrite(match[2]) + match[3] + rewrite(match[4]) + match[5];
+    }
+    match = line.match(BINARY);
+    if (match) {
+      return match[1] + rewrite(match[2]) + match[3] + rewrite(match[4]) + match[5];
+    }
+    match = line.match(FILE_MARKER);
+    if (match) {
+      return match[1] + match[2] + rewrite(match[3]) + match[4];
+    }
+    match = line.match(RENAME);
+    if (match) {
+      return match[1] + rewrite(match[2]);
+    }
+    return line;
+  }).join('\n');
+
+  stats.untranslated = [...new Set(stats.untranslated)];
+  return {text, stats};
+};
+
+module.exports = {buildPackageMap, translatePatch};

--- a/src/patch-translate.js
+++ b/src/patch-translate.js
@@ -12,7 +12,12 @@ const fs = require('fs');
 const path = require('path');
 const {execFileSync} = require('child_process');
 const packagesConfig = require('./build-config/packages-config');
-const {buildConfig: releaseInstructions} = require('./build-config/mageos-release-build-config');
+// Required for its load-time side effect: mageos-release-build-config mutates
+// the shared packages-config object in place, which is what renames the base
+// package template to mage-os/magento2-base. Without this require the map
+// would name magento/magento2-base and to-vendor output would carry the wrong
+// namespace, and no test would fail.
+require('./build-config/mageos-release-build-config');
 
 /**
  * Directories whose immediate subdirectories are each their own package, as
@@ -138,7 +143,11 @@ const buildPackageMap = ({repoDir, ref, definitionKey = 'magento2', gitRepoDir})
       ),
       packageIndividual: dedupeBy(
         Object.values(packagesConfig).flatMap(d => d.packageIndividual || []),
-        entry => entry.dir
+        // dir alone is not unique here: dozens of base-package entries share
+        // dir '' and differ only in which composer template names them.
+        entry => typeof entry.dir === 'string'
+          ? `${entry.dir} ${entry.composerJsonPath || ''}`
+          : undefined
       ),
     };
 
@@ -234,7 +243,7 @@ const isInstallOnly = (path) => path !== '/dev/null'
 // file marker; only position separates them, so the walk below tracks it.
 const DIFF_GIT = /^(diff --git )(\S+)( )(\S+)(.*)$/;
 const FILE_MARKER = /^(---|\+\+\+)(\s+)(\S+)(.*)$/;
-const RENAME = /^(rename (?:from|to) )(.+)$/;
+const RENAME_OR_COPY = /^((?:rename|copy) (?:from|to) )(.+)$/;
 const BINARY = /^(Binary files )(\S+)( and )(\S+)( differ)$/;
 
 /**
@@ -295,7 +304,7 @@ const rewriteHeaderPaths = (lines, rewrite) => {
     if (match) {
       return match[1] + match[2] + rewrite(match[3]) + match[4];
     }
-    match = line.match(RENAME);
+    match = line.match(RENAME_OR_COPY);
     if (match) {
       return match[1] + rewrite(match[2]);
     }
@@ -341,6 +350,14 @@ const translatePatch = (patchText, packageMap, direction) => {
 
   const rewrite = (path) => {
     if (path === '/dev/null') return path;
+    // Git C-quotes a path containing spaces or specials, and the header
+    // regexes split on whitespace, so what arrives here is a mangled fragment.
+    // Refusing to translate keeps the line byte-identical and reports the
+    // fragment as untranslated, instead of silently emitting a corrupt path.
+    if (path.includes('"')) {
+      stats.untranslated.push(bare(path));
+      return path;
+    }
     const out = withPrefix(path, translate);
     if (out === null) {
       // A section whose header named an install-only path is already gone. This

--- a/src/patch-translate.js
+++ b/src/patch-translate.js
@@ -203,6 +203,17 @@ const makeTranslators = (packageMap) => {
   return {sourceToVendor, vendorToSource};
 };
 
+/**
+ * Paths that exist only in an installed tree and have no source tree
+ * counterpart. Composer generates vendor/bin from package definitions, and
+ * Adobe ships a patch-status marker there to track which isolated patches an
+ * installation has applied. Hunks touching these are dropped rather than
+ * failing the translation, because a source tree port must not contain them.
+ */
+const INSTALL_ONLY = [/^vendor\/bin\//];
+
+const isInstallOnly = (path) => INSTALL_ONLY.some(pattern => pattern.test(path.replace(/^[ab]\//, '')));
+
 // Matches the path-bearing lines of a unified diff. Trailing text after the
 // path (timestamps, tabs) is preserved verbatim.
 const DIFF_GIT = /^(diff --git )(\S+)( )(\S+)(.*)$/;
@@ -230,7 +241,27 @@ const translatePatch = (patchText, packageMap, direction) => {
     throw new Error(`Unknown direction "${direction}", expected to-vendor or to-source`);
   }
 
-  const stats = {translated: 0, untranslated: []};
+  const stats = {translated: 0, untranslated: [], dropped: []};
+
+  // Sections are split on diff --git so a dropped file takes its hunks with it.
+  const sections = [];
+  for (const line of patchText.split('\n')) {
+    if (line.startsWith('diff --git ') || sections.length === 0) sections.push([]);
+    sections[sections.length - 1].push(line);
+  }
+
+  const kept = sections.filter(section => {
+    const header = section[0].match(DIFF_GIT);
+    if (!header) return true;
+    const target = header[4];
+    if (direction === 'to-source' && isInstallOnly(target)) {
+      stats.dropped.push(target.replace(/^[ab]\//, ''));
+      return false;
+    }
+    return true;
+  });
+
+  patchText = kept.map(section => section.join('\n')).join('\n');
 
   const rewrite = (path) => {
     if (path === '/dev/null') return path;
@@ -264,6 +295,7 @@ const translatePatch = (patchText, packageMap, direction) => {
   }).join('\n');
 
   stats.untranslated = [...new Set(stats.untranslated)];
+  stats.dropped = [...new Set(stats.dropped)];
   return {text, stats};
 };
 

--- a/src/patch-translate.js
+++ b/src/patch-translate.js
@@ -171,6 +171,10 @@ const makeTranslators = (packageMap) => {
 
   const sourceToVendor = (path) => {
     for (const [name, dir] of byDepth) {
+      // Sorted longest first, so the base package's empty dir is reached last
+      // and acts as the fallback for the unpackaged paths it owns (lib/web,
+      // app/etc) rather than never matching at all.
+      if (dir === '') return `vendor/${name}/${path}`;
       if (path === dir) return `vendor/${name}`;
       if (path.startsWith(`${dir}/`)) return `vendor/${name}${path.slice(dir.length)}`;
     }
@@ -212,10 +216,17 @@ const makeTranslators = (packageMap) => {
  */
 const INSTALL_ONLY = [/^vendor\/bin\//];
 
-const isInstallOnly = (path) => INSTALL_ONLY.some(pattern => pattern.test(path.replace(/^[ab]\//, '')));
+const bare = (path) => path.replace(/^[ab]\//, '');
+
+const isInstallOnly = (path) => path !== '/dev/null'
+  && INSTALL_ONLY.some(pattern => pattern.test(bare(path)));
 
 // Matches the path-bearing lines of a unified diff. Trailing text after the
 // path (timestamps, tabs) is preserved verbatim.
+//
+// These shapes are only meaningful in a header position. A removed line whose
+// own content begins "-- " arrives as "--- ...", which no regex can tell from a
+// file marker; only position separates them, so the walk below tracks it.
 const DIFF_GIT = /^(diff --git )(\S+)( )(\S+)(.*)$/;
 const FILE_MARKER = /^(---|\+\+\+)(\s+)(\S+)(.*)$/;
 const RENAME = /^(rename (?:from|to) )(.+)$/;
@@ -234,12 +245,65 @@ const withPrefix = (path, translate) => {
   return translated === null ? null : prefix + translated;
 };
 
+const HUNK_HEADER = /^@@ -\d+(?:,(\d+))? \+\d+(?:,(\d+))? @@/;
+
+/**
+ * Applies rewrite to the path-bearing header lines only, skipping hunk bodies.
+ *
+ * Hunk extent comes from the @@ line counts rather than from the next header:
+ * a plain diff -u has no per-file header to stop at, and the corpus contains
+ * both framings.
+ */
+const rewriteHeaderPaths = (lines, rewrite) => {
+  let oldRemaining = 0;
+  let newRemaining = 0;
+
+  return lines.map(line => {
+    if (oldRemaining > 0 || newRemaining > 0) {
+      if (line.startsWith('\\')) return line; // "\ No newline at end of file"
+      if (line.startsWith('-')) oldRemaining = Math.max(0, oldRemaining - 1);
+      else if (line.startsWith('+')) newRemaining = Math.max(0, newRemaining - 1);
+      else {
+        oldRemaining = Math.max(0, oldRemaining - 1);
+        newRemaining = Math.max(0, newRemaining - 1);
+      }
+      return line;
+    }
+
+    const hunk = line.match(HUNK_HEADER);
+    if (hunk) {
+      // An omitted count means one line, per the unified diff format.
+      oldRemaining = hunk[1] === undefined ? 1 : parseInt(hunk[1], 10);
+      newRemaining = hunk[2] === undefined ? 1 : parseInt(hunk[2], 10);
+      return line;
+    }
+
+    let match = line.match(DIFF_GIT);
+    if (match) {
+      return match[1] + rewrite(match[2]) + match[3] + rewrite(match[4]) + match[5];
+    }
+    match = line.match(BINARY);
+    if (match) {
+      return match[1] + rewrite(match[2]) + match[3] + rewrite(match[4]) + match[5];
+    }
+    match = line.match(FILE_MARKER);
+    if (match) {
+      return match[1] + match[2] + rewrite(match[3]) + match[4];
+    }
+    match = line.match(RENAME);
+    if (match) {
+      return match[1] + rewrite(match[2]);
+    }
+    return line;
+  });
+};
+
 const translatePatch = (patchText, packageMap, direction) => {
-  const {sourceToVendor, vendorToSource} = makeTranslators(packageMap);
-  const translate = direction === 'to-vendor' ? sourceToVendor : vendorToSource;
   if (direction !== 'to-vendor' && direction !== 'to-source') {
     throw new Error(`Unknown direction "${direction}", expected to-vendor or to-source`);
   }
+  const {sourceToVendor, vendorToSource} = makeTranslators(packageMap);
+  const translate = direction === 'to-vendor' ? sourceToVendor : vendorToSource;
 
   const stats = {translated: 0, untranslated: [], dropped: []};
 
@@ -258,9 +322,11 @@ const translatePatch = (patchText, packageMap, direction) => {
   const kept = sections.filter(section => {
     const header = section[0].match(DIFF_GIT);
     if (!header) return true;
-    const target = header[4];
-    if (direction === 'to-source' && isInstallOnly(target)) {
-      stats.dropped.push(target.replace(/^[ab]\//, ''));
+    // Either side, because a deletion can carry the real path on only one of
+    // them depending on which tool wrote the diff.
+    const target = [header[4], header[2]].find(isInstallOnly);
+    if (direction === 'to-source' && target) {
+      stats.dropped.push(bare(target));
       return false;
     }
     return true;
@@ -272,32 +338,18 @@ const translatePatch = (patchText, packageMap, direction) => {
     if (path === '/dev/null') return path;
     const out = withPrefix(path, translate);
     if (out === null) {
-      stats.untranslated.push(path.replace(/^[ab]\//, ''));
+      // A section whose header named an install-only path is already gone. This
+      // catches the same path in a diff -u run that has no header to drop.
+      if (!(direction === 'to-source' && isInstallOnly(path))) {
+        stats.untranslated.push(bare(path));
+      }
       return path;
     }
     stats.translated++;
     return out;
   };
 
-  const text = patchText.split('\n').map(line => {
-    let match = line.match(DIFF_GIT);
-    if (match) {
-      return match[1] + rewrite(match[2]) + match[3] + rewrite(match[4]) + match[5];
-    }
-    match = line.match(BINARY);
-    if (match) {
-      return match[1] + rewrite(match[2]) + match[3] + rewrite(match[4]) + match[5];
-    }
-    match = line.match(FILE_MARKER);
-    if (match) {
-      return match[1] + match[2] + rewrite(match[3]) + match[4];
-    }
-    match = line.match(RENAME);
-    if (match) {
-      return match[1] + rewrite(match[2]);
-    }
-    return line;
-  }).join('\n');
+  const text = rewriteHeaderPaths(patchText.split('\n'), rewrite).join('\n');
 
   stats.untranslated = [...new Set(stats.untranslated)];
   stats.dropped = [...new Set(stats.dropped)];

--- a/tests/unit/patch-translate.test.js
+++ b/tests/unit/patch-translate.test.js
@@ -150,3 +150,48 @@ describe('translatePatch validation', () => {
     expect(() => translatePatch('', packageMap, 'sideways')).toThrow(/Unknown direction/);
   });
 });
+
+describe('translatePatch cases found in the upstream quality-patches corpus', () => {
+  // Packages whose repository root is the package container, so the module
+  // directory sits at the top level rather than under app/code/Magento.
+  const withRootPackages = new Map([
+    ...packageMap,
+    ['magento/module-inventory-catalog', 'InventoryCatalog'],
+    ['magento/magento2-base', ''],
+  ]);
+
+  const toSourceWith = (patch, map = withRootPackages) =>
+    translatePatch(patch, map, 'to-source');
+
+  it('maps a package that lives at a repository root', () => {
+    const patch = '--- a/vendor/magento/module-inventory-catalog/Model/Source.php';
+
+    expect(toSourceWith(patch).text).toBe('--- a/InventoryCatalog/Model/Source.php');
+  });
+
+  it('maps the base package without leaving a leading slash', () => {
+    const patch = '--- a/vendor/magento/magento2-base/app/etc/di.xml';
+
+    expect(toSourceWith(patch).text).toBe('--- a/app/etc/di.xml');
+  });
+
+  it('passes through paths that are already source relative', () => {
+    const patch = [
+      'diff --git a/lib/web/mage/menu.js b/lib/web/mage/menu.js',
+      '--- a/lib/web/mage/menu.js',
+      '+++ b/lib/web/mage/menu.js',
+    ].join('\n');
+
+    const {text, stats} = toSourceWith(patch);
+
+    expect(text).toBe(patch);
+    expect(stats.untranslated).toEqual([]);
+  });
+
+  it('still refuses an unknown third party vendor package', () => {
+    const patch = '--- a/vendor/paypal/module-braintree-core/Model/Ui.php';
+    const {stats} = toSourceWith(patch);
+
+    expect(stats.untranslated).toEqual(['vendor/paypal/module-braintree-core/Model/Ui.php']);
+  });
+});

--- a/tests/unit/patch-translate.test.js
+++ b/tests/unit/patch-translate.test.js
@@ -260,3 +260,103 @@ describe('translatePatch output framing', () => {
     expect(translatePatch(patch, packageMap, 'to-source').text.endsWith('\n')).toBe(false);
   });
 });
+
+describe('translatePatch hunk bodies', () => {
+  const withBase = new Map([...packageMap, ['magento/magento2-base', '']]);
+
+  it('leaves a removed line alone when its own content starts with two dashes', () => {
+    // The file's line is the SQL comment "-- vendor/...", so its removed form in
+    // the diff is "--- vendor/...", which has the exact shape of a file marker.
+    const patch = [
+      'diff --git a/vendor/magento/module-cms/setup.sql b/vendor/magento/module-cms/setup.sql',
+      '--- a/vendor/magento/module-cms/setup.sql',
+      '+++ b/vendor/magento/module-cms/setup.sql',
+      '@@ -1,2 +1,2 @@',
+      '--- vendor/magento/module-cms/legacy.sql',
+      '+++ vendor/magento/module-cms/legacy2.sql',
+    ].join('\n');
+
+    const {text, stats} = toSource(patch);
+    const body = text.split('\n').slice(4);
+
+    expect(body).toEqual([
+      '--- vendor/magento/module-cms/legacy.sql',
+      '+++ vendor/magento/module-cms/legacy2.sql',
+    ]);
+    // Four header paths, and nothing from the body.
+    expect(stats.translated).toBe(4);
+  });
+
+  it('resumes rewriting once a hunk has run its declared length', () => {
+    const patch = [
+      '--- a/vendor/magento/module-cms/A.php',
+      '+++ b/vendor/magento/module-cms/A.php',
+      '@@ -1,1 +1,1 @@',
+      '-one',
+      '+two',
+      '--- a/vendor/magento/framework/B.php',
+      '+++ b/vendor/magento/framework/B.php',
+    ].join('\n');
+
+    const {text} = toSource(patch);
+
+    expect(text).toContain('--- a/lib/internal/Magento/Framework/B.php');
+    expect(text).toContain('+++ b/lib/internal/Magento/Framework/B.php');
+  });
+
+  it('treats an omitted hunk count as one line', () => {
+    const patch = [
+      '--- a/vendor/magento/module-cms/A.php',
+      '+++ b/vendor/magento/module-cms/A.php',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      '--- a/vendor/magento/framework/B.php',
+    ].join('\n');
+
+    expect(toSource(patch).text).toContain('--- a/lib/internal/Magento/Framework/B.php');
+  });
+
+  it('does not let a no-newline marker consume a hunk line', () => {
+    const patch = [
+      '--- a/vendor/magento/module-cms/A.php',
+      '+++ b/vendor/magento/module-cms/A.php',
+      '@@ -1,1 +1,1 @@',
+      '-old',
+      '\\ No newline at end of file',
+      '+new',
+      '--- a/vendor/magento/framework/B.php',
+    ].join('\n');
+
+    expect(toSource(patch).text).toContain('--- a/lib/internal/Magento/Framework/B.php');
+  });
+
+  it('drops an install-only section when only the a side carries the path', () => {
+    const patch = [
+      'diff --git a/vendor/bin/magento-patches b/dev/null',
+      'deleted file mode 100644',
+      '--- a/vendor/bin/magento-patches',
+      '+++ /dev/null',
+    ].join('\n');
+
+    const {stats} = translatePatch(patch, packageMap, 'to-source');
+
+    expect(stats.dropped).toEqual(['vendor/bin/magento-patches']);
+    expect(stats.untranslated).toEqual([]);
+  });
+
+  it('does not report an install-only path as unmapped when there is no header to drop', () => {
+    const patch = '--- a/vendor/bin/magento-patches';
+
+    expect(translatePatch(patch, packageMap, 'to-source').stats.untranslated).toEqual([]);
+  });
+
+  it('maps base package paths in the to-vendor direction', () => {
+    const patch = '--- a/lib/web/mage/menu.js';
+
+    const {text, stats} = translatePatch(patch, withBase, 'to-vendor');
+
+    expect(text).toBe('--- a/vendor/magento/magento2-base/lib/web/mage/menu.js');
+    expect(stats.untranslated).toEqual([]);
+  });
+});

--- a/tests/unit/patch-translate.test.js
+++ b/tests/unit/patch-translate.test.js
@@ -228,3 +228,35 @@ describe('translatePatch install-only paths', () => {
     expect(text).toContain('+new');
   });
 });
+
+describe('translatePatch output framing', () => {
+  it('keeps the trailing newline when the dropped section was last', () => {
+    const patch = [
+      'diff --git a/vendor/magento/module-cms/Model/Page.php b/vendor/magento/module-cms/Model/Page.php',
+      '--- a/vendor/magento/module-cms/Model/Page.php',
+      '+++ b/vendor/magento/module-cms/Model/Page.php',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+      'diff --git a/vendor/bin/patch-status b/vendor/bin/patch-status',
+      '--- a/vendor/bin/patch-status',
+      '+++ b/vendor/bin/patch-status',
+      '@@ -1 +1 @@',
+      '-marker',
+      '+marker2',
+      '',
+    ].join('\n');
+
+    const {text, stats} = translatePatch(patch, packageMap, 'to-source');
+
+    expect(stats.dropped).toEqual(['vendor/bin/patch-status']);
+    // git apply reports "corrupt patch" without this.
+    expect(text.endsWith('\n')).toBe(true);
+  });
+
+  it('does not invent a trailing newline the input lacked', () => {
+    const patch = '--- a/vendor/magento/module-cms/Model/Page.php';
+
+    expect(translatePatch(patch, packageMap, 'to-source').text.endsWith('\n')).toBe(false);
+  });
+});

--- a/tests/unit/patch-translate.test.js
+++ b/tests/unit/patch-translate.test.js
@@ -360,3 +360,35 @@ describe('translatePatch hunk bodies', () => {
     expect(stats.untranslated).toEqual([]);
   });
 });
+
+describe('translatePatch copy headers', () => {
+  it('rewrites copy from/to headers the way it rewrites renames', () => {
+    const patch = [
+      'copy from vendor/magento/module-cms/Model/Old.php',
+      'copy to vendor/magento/module-cms/Model/New.php',
+    ].join('\n');
+
+    expect(toSource(patch).text).toBe([
+      'copy from app/code/Magento/Cms/Model/Old.php',
+      'copy to app/code/Magento/Cms/Model/New.php',
+    ].join('\n'));
+  });
+});
+
+describe('translatePatch git-quoted paths', () => {
+  // Git C-quotes paths containing spaces. The header regexes split on
+  // whitespace and cannot reassemble the quoted form, so the contract is to
+  // leave the line byte-identical and report it, never to emit fragments.
+  it('leaves a quoted header untouched and reports it untranslated', () => {
+    const patch = [
+      'diff --git "a/vendor/magento/module-cms/x y.php" "b/vendor/magento/module-cms/x y.php"',
+      '--- "a/vendor/magento/module-cms/x y.php"',
+      '+++ "b/vendor/magento/module-cms/x y.php"',
+    ].join('\n');
+
+    const {text, stats} = toSource(patch);
+
+    expect(text).toBe(patch);
+    expect(stats.untranslated.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/patch-translate.test.js
+++ b/tests/unit/patch-translate.test.js
@@ -1,0 +1,152 @@
+const {translatePatch} = require('../../src/patch-translate');
+
+// A stand-in for what buildPackageMap reads out of a git ref, covering the three
+// shapes that matter: a module, a nested package, and the parent that contains it.
+const packageMap = new Map([
+  ['magento/module-cms', 'app/code/Magento/Cms'],
+  ['magento/module-media-gallery-ui-api', 'app/code/Magento/MediaGalleryUiApi'],
+  ['magento/framework', 'lib/internal/Magento/Framework'],
+  ['magento/framework-amqp', 'lib/internal/Magento/Framework/Amqp'],
+  ['magento/theme-frontend-luma', 'app/design/frontend/Magento/luma'],
+]);
+
+const toSource = (patch) => translatePatch(patch, packageMap, 'to-source');
+const toVendor = (patch) => translatePatch(patch, packageMap, 'to-vendor');
+
+describe('translatePatch to-source', () => {
+  it('rewrites git diff headers and file markers', () => {
+    const patch = [
+      'diff --git a/vendor/magento/module-cms/Model/Page.php b/vendor/magento/module-cms/Model/Page.php',
+      'index 7acd00c..396b08a 100644',
+      '--- a/vendor/magento/module-cms/Model/Page.php',
+      '+++ b/vendor/magento/module-cms/Model/Page.php',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+    ].join('\n');
+
+    const {text, stats} = toSource(patch);
+
+    expect(text).toContain('diff --git a/app/code/Magento/Cms/Model/Page.php b/app/code/Magento/Cms/Model/Page.php');
+    expect(text).toContain('--- a/app/code/Magento/Cms/Model/Page.php');
+    expect(text).toContain('+++ b/app/code/Magento/Cms/Model/Page.php');
+    expect(stats.translated).toBe(4);
+    expect(stats.untranslated).toEqual([]);
+  });
+
+  it('handles markers without a/ b/ prefixes', () => {
+    const patch = [
+      '--- vendor/magento/module-cms/Model/Page.php',
+      '+++ vendor/magento/module-cms/Model/Page.php',
+    ].join('\n');
+
+    expect(toSource(patch).text).toBe([
+      '--- app/code/Magento/Cms/Model/Page.php',
+      '+++ app/code/Magento/Cms/Model/Page.php',
+    ].join('\n'));
+  });
+
+  it('preserves trailing timestamps on file markers', () => {
+    const patch = '--- vendor/magento/module-cms/Model/Page.php\t2026-08-11 10:00:00.000000000 +0000';
+
+    expect(toSource(patch).text)
+      .toBe('--- app/code/Magento/Cms/Model/Page.php\t2026-08-11 10:00:00.000000000 +0000');
+  });
+
+  it('leaves /dev/null alone for added files', () => {
+    const patch = [
+      '--- /dev/null',
+      '+++ b/vendor/magento/module-cms/Model/New.php',
+    ].join('\n');
+
+    const {text, stats} = toSource(patch);
+
+    expect(text).toContain('--- /dev/null');
+    expect(text).toContain('+++ b/app/code/Magento/Cms/Model/New.php');
+    expect(stats.untranslated).toEqual([]);
+  });
+
+  it('prefers the deepest matching package', () => {
+    const patch = '--- a/vendor/magento/framework-amqp/Config.php';
+
+    expect(toSource(patch).text).toBe('--- a/lib/internal/Magento/Framework/Amqp/Config.php');
+  });
+
+  it('accepts mage-os vendor names for packages declared as magento in source', () => {
+    const patch = '--- a/vendor/mage-os/module-cms/Model/Page.php';
+
+    expect(toSource(patch).text).toBe('--- a/app/code/Magento/Cms/Model/Page.php');
+  });
+
+  it('rewrites rename headers', () => {
+    const patch = [
+      'rename from vendor/magento/module-cms/Model/Old.php',
+      'rename to vendor/magento/module-cms/Model/New.php',
+    ].join('\n');
+
+    expect(toSource(patch).text).toBe([
+      'rename from app/code/Magento/Cms/Model/Old.php',
+      'rename to app/code/Magento/Cms/Model/New.php',
+    ].join('\n'));
+  });
+
+  it('rewrites binary file markers', () => {
+    const patch = 'Binary files a/vendor/magento/module-cms/logo.png and b/vendor/magento/module-cms/logo.png differ';
+
+    expect(toSource(patch).text)
+      .toBe('Binary files a/app/code/Magento/Cms/logo.png and b/app/code/Magento/Cms/logo.png differ');
+  });
+
+  it('reports unknown packages instead of mangling them', () => {
+    const patch = '--- a/vendor/acme/module-unknown/Model/Thing.php';
+    const {text, stats} = toSource(patch);
+
+    expect(text).toBe(patch);
+    expect(stats.translated).toBe(0);
+    expect(stats.untranslated).toEqual(['vendor/acme/module-unknown/Model/Thing.php']);
+  });
+
+  it('leaves hunk bodies untouched even when they look like paths', () => {
+    const patch = [
+      '--- a/vendor/magento/module-cms/Model/Page.php',
+      '+++ b/vendor/magento/module-cms/Model/Page.php',
+      '@@ -1,2 +1,2 @@',
+      "-require 'vendor/magento/module-cms/bootstrap.php';",
+      "+require 'vendor/magento/module-cms/bootstrap2.php';",
+    ].join('\n');
+
+    const {text} = toSource(patch);
+
+    expect(text).toContain("-require 'vendor/magento/module-cms/bootstrap.php';");
+    expect(text).toContain("+require 'vendor/magento/module-cms/bootstrap2.php';");
+  });
+});
+
+describe('translatePatch to-vendor', () => {
+  it('inverts the source mapping', () => {
+    const patch = '--- a/app/code/Magento/MediaGalleryUiApi/etc/acl.xml';
+
+    expect(toVendor(patch).text).toBe('--- a/vendor/magento/module-media-gallery-ui-api/etc/acl.xml');
+  });
+
+  it('round-trips without loss', () => {
+    const original = [
+      'diff --git a/app/code/Magento/Cms/Model/Page.php b/app/code/Magento/Cms/Model/Page.php',
+      '--- a/app/code/Magento/Cms/Model/Page.php',
+      '+++ b/app/code/Magento/Cms/Model/Page.php',
+      '--- a/lib/internal/Magento/Framework/Amqp/Config.php',
+      '--- a/app/design/frontend/Magento/luma/web/css/source/_theme.less',
+    ].join('\n');
+
+    const vendored = toVendor(original).text;
+
+    expect(vendored).not.toBe(original);
+    expect(toSource(vendored).text).toBe(original);
+  });
+});
+
+describe('translatePatch validation', () => {
+  it('rejects an unknown direction', () => {
+    expect(() => translatePatch('', packageMap, 'sideways')).toThrow(/Unknown direction/);
+  });
+});

--- a/tests/unit/patch-translate.test.js
+++ b/tests/unit/patch-translate.test.js
@@ -195,3 +195,36 @@ describe('translatePatch cases found in the upstream quality-patches corpus', ()
     expect(stats.untranslated).toEqual(['vendor/paypal/module-braintree-core/Model/Ui.php']);
   });
 });
+
+describe('translatePatch install-only paths', () => {
+  const patch = [
+    'diff --git a/vendor/magento/module-cms/Model/Page.php b/vendor/magento/module-cms/Model/Page.php',
+    '--- a/vendor/magento/module-cms/Model/Page.php',
+    '+++ b/vendor/magento/module-cms/Model/Page.php',
+    '@@ -1 +1 @@',
+    '-old',
+    '+new',
+    'diff --git a/vendor/bin/patch-status b/vendor/bin/patch-status',
+    '--- a/vendor/bin/patch-status',
+    '+++ b/vendor/bin/patch-status',
+    '@@ -1 +1 @@',
+    '-marker',
+    '+marker2',
+  ].join('\n');
+
+  it('drops vendor/bin hunks instead of failing the whole patch', () => {
+    const {text, stats} = translatePatch(patch, packageMap, 'to-source');
+
+    expect(stats.untranslated).toEqual([]);
+    expect(stats.dropped).toEqual(['vendor/bin/patch-status']);
+    expect(text).not.toContain('patch-status');
+    expect(text).not.toContain('-marker');
+  });
+
+  it('keeps the rest of the patch intact', () => {
+    const {text} = translatePatch(patch, packageMap, 'to-source');
+
+    expect(text).toContain('--- a/app/code/Magento/Cms/Model/Page.php');
+    expect(text).toContain('+new');
+  });
+});


### PR DESCRIPTION
## Translate Adobe isolated security patches to source tree paths

### The problem

Adobe ships isolated security patches against an **installed** tree:

	--- a/vendor/magento/module-cms/Controller/Adminhtml/Wysiwyg/Images/Upload.php

`mageos-magento2` is a **source** tree, so every path in the patch has to be rewritten before it can be applied. 

Adobe ships these as `vendor/`-level patches; this PR maps them onto `app/code/`.

### Map/Translate 

The mapping is already in this repository, because the build performs the same transform in the forward direction on every release: `src/build-config/packages-config.js`.

The translator does not hardcode any mapping. It reads each package's own `composer.json` at a given ref, driven by the `packageDirs` and `packageIndividual` entries in that config, and therefore cannot drift from what the build produces.

### What this adds

| File                                 | Purpose                                                                                                                           |
| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
| `src/patch-translate.js`             | Builds the package↔directory map and rewrites patch paths in either direction                                                     |
| `bin/translate-patch.js`             | Translates one patch. Exits non-zero on any untranslatable path rather than emitting a partial patch                              |
| `bin/apply-security-patch.js`        | Applies a patch across several release lines, one committed branch per line, reporting clean/partial/rejected/unmapped per target |
| `tests/unit/patch-translate.test.js` | 23 tests                                                                                                                          |

No network access, no discovery, no automatic decisions. The patch file is an input. Output is a branch for human review.

### Validation

**Against the real Adobe patch.** `249-2026-08-001-CE.patch`, the file #320 was ported from by hand, translates with no special casing: 36 path references, one install-only path dropped (below). Nine of its ten files map to the source tree.

**Against the whole upstream corpus.** The Open Source and community patches in `magento/quality-patches` are real upstream patch files in the installed layout, so they are the widest available test of path shapes. Against version 1.1.59, 912 of them:

| Map                               | Packages | Fully translated       |
| --------------------------------- | -------- | ---------------------- |
| `--repoDir` alone (`magento2`)    | 238      | 746 of 912 — 81.8%     |
| `--gitRepoDir` adding `inventory` | 313      | 849 of 912 — **93.1%** |

Every inventory module leaves the failure list between those two rows, which is what `--gitRepoDir` is for: a patch may touch packages from any repository the distribution is built from, and a map built from `magento2` alone cannot resolve them. Adding checkouts of `page-builder` and `security-package` accounts for most of what remains. The residual failures after that are correct refusals: `paypal`, `dotmailer` and `vertex` are third party dependencies with no source tree location, and `elasticsearch-6`, `elasticsearch-7` and `module-company` are not in current Magento Open Source. Those hard fail rather than silently dropping hunks from a security patch.

**Across two release lines.** Adobe publishes a separate isolated patch per upstream line, and the `upstream` key already in the `supported-version` data says which one a Mage-OS line needs. Applying each line's own patch to the commit its last release was tagged from:

| Line | Upstream | Patch                  | Result           |
| ---- | -------- | ---------------------- | ---------------- |
| 2.x  | 2.4.8-p5 | `248p5-2026-08-001-CE` | clean, 9/9 files |
| 3.x  | 2.4.9    | `249-2026-08-001-CE`   | 8/9, see below   |

The 3.x rejection is correct. Mage-OS had already upgraded underscore to 1.13.8 in #309, from a differently formatted source, so Adobe's 1.13.7 → 1.13.8 hunk matches neither forward nor in reverse. #320 omitted that file for the same reason.

`git apply` is atomic, so one file rolls the rest back. Because a hunk that fails for this reason is indistinguishable from a real conflict in git's output, the applier reports what blocked it and how much of the patch is already present:

`REJECTED  rolled back, blocked by: lib/web/underscore.js (85% of added lines already present)`

That is left as a signal for the reviewer.

### Partial mode

`git apply --3way` is atomic: one conflicting file rolls the whole patch back. For a 32 file security patch where a single hunk has drifted, discarding the other 30 fixes is the wrong default.

`--partial` uses `--reject` instead, applying what applies and leaving `.rej` files for the rest. git refuses `--reject` and `--3way` together, so this is a mode rather than an added flag. Rejected hunks stay uncommitted: they are working notes for whoever resolves the conflict, not part of the port.

### Applied to a real release line

Worked through end to end at [melindash/mageos-magento2#1](https://github.com/melindash/mageos-magento2/pull/1): Adobe's July and August isolated patches for 2.4.8-p5, applied in the order Adobe requires, to the commit Mage-OS 2.3.0 shipped from.

| Step                           | Result                                        |
| ------------------------------ | --------------------------------------------- |
| July, `248p5-2026-07-001-CE`   | 30 of 31 files applied, 1 rejected            |
| Human                          | the rejected hunk, resolved in its own commit |
| August, `248p5-2026-08-001-CE` | 9 of 9, clean                                 |

39 of 40 files mechanical. The one rejection is the divergence case: Adobe appends a plugin to `Magento/Quote/etc/di.xml` expecting a particular last entry before `</config>`, and that line has three of its own declarations after it. Resolving it means deciding where one line goes, not re-deriving a fix.

### Things worth knowing in review

- **`vendor/bin` hunks are dropped, and reported.** Adobe writes a `vendor/bin/patch-status` marker so its version tool can tell which isolated patches an installation has applied. Composer generates `vendor/bin`, so it has no source tree counterpart. Every monthly patch carries this, and treating it as untranslatable failed the whole patch.
- **Paths already relative to the source root pass through, and only those.** Some upstream patches address `lib/web/mage/menu.js`, `app/etc/di.xml` or `nginx.conf.sample` directly, and those need no translation. Pass-through requires the first segment to be a real top level entry of the repository at that ref, read with `ls-tree` rather than listed in code so it cannot drift. Without that check any unrecognised shape passed through unchanged and was counted as translated, which is how a module-relative patch reached `git apply` reported as clean.
- **Vendor names are matched in both directions.** A checkout declares `magento/*`, published packages are renamed to `mage-os/*`, and a checkout that a release build has touched carries the latter.
- **The map spans repositories.** Inventory, page builder and security package modules live in their own repositories, so `--gitRepoDir` builds the map across every checkout found there. It reads the checkouts as directories, so symlinked repositories are skipped.


### Not automated by this PR

- It does not detect that a patch exists. That is a separate concern. 
- It does not download anything. `--patch` is a required input.
- It does not decide whether a rejected hunk is safe to skip.
- It does not guess the module a module-relative patch belongs to.
- It cannot add a Composer dependency the patch does not carry. An isolated patch operates on an installed tree where dependencies are already resolved, so the `app/code/Magento/Cms/composer.json` change in #320 could not have come from Adobe's patch. That remains a human step.



A complete release build was produced twice from the same cloned repositories, once from unmodified `main` and once with this branch applied: 10,807 packages each, 7.2 GB each, and the SHA-1 of every archive identical.

Full suite: 900 → 934 passing.